### PR TITLE
fix: show feedback when manual update check fails or is blocked

### DIFF
--- a/apps/electron/main/i18n.ts
+++ b/apps/electron/main/i18n.ts
@@ -41,7 +41,8 @@ type MessageKey =
     | 'updater.skipCleared'
     | 'updater.channelChanged'
     | 'updater.channelChangedDetail'
-    | 'updater.channelBusy';
+    | 'updater.channelBusy'
+    | 'updater.updateInProgress';
 
 const MESSAGES: Record<SupportedLocale, Record<MessageKey, string>> = {
     'zh-CN': {
@@ -84,6 +85,7 @@ const MESSAGES: Record<SupportedLocale, Record<MessageKey, string>> = {
         'updater.channelChanged': '更新通道已切换',
         'updater.channelChangedDetail': '当前更新通道：{channel}。之后会按该通道检查更新。',
         'updater.channelBusy': '当前正在执行更新任务，请完成后再切换更新通道。',
+        'updater.updateInProgress': '正在检查或下载更新，请稍后再试。',
     },
     'en-US': {
         'menu.checkForUpdates': 'Check for Updates',
@@ -125,6 +127,7 @@ const MESSAGES: Record<SupportedLocale, Record<MessageKey, string>> = {
         'updater.channelChanged': 'Update channel changed',
         'updater.channelChangedDetail': 'Current update channel: {channel}. Future checks will use this channel.',
         'updater.channelBusy': 'Finish the current update task before switching update channels.',
+        'updater.updateInProgress': 'An update check or download is already in progress. Please try again later.',
     },
 };
 

--- a/apps/electron/main/updater.ts
+++ b/apps/electron/main/updater.ts
@@ -339,16 +339,41 @@ function showNoUpdateDialog(t: MainTranslator) {
     dialog.showMessageBox(options);
 }
 
-function showUpdateError(logError: LogFn, error: unknown) {
+function showUpdateError(logError: LogFn, t: MainTranslator, error: unknown, manual: boolean) {
     const rawMessage = error instanceof Error ? error.message : String(error);
     const compactRaw = rawMessage.replace(/\s+/g, ' ').trim();
-    logError('[updater] update flow failed (silent):', compactRaw || rawMessage || error);
+    logError('[updater] update flow failed:', compactRaw || rawMessage || error);
 
     const mainWindow = getMainWindow();
     if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.setProgressBar(-1);
     }
     closeAllDialogs();
+
+    if (manual) {
+        let detail: string;
+        const lower = compactRaw.toLowerCase();
+        if (lower.includes('net::') || lower.includes('enotfound') || lower.includes('etimedout') || lower.includes('econnrefused') || lower.includes('network')) {
+            detail = t('updater.checkFailedNetwork');
+        } else if (lower.includes('404') || lower.includes('502') || lower.includes('503') || lower.includes('server')) {
+            detail = t('updater.checkFailedServer');
+        } else {
+            detail = t('updater.checkFailedGeneric');
+        }
+        const options: MessageBoxOptions = {
+            type: 'warning',
+            title: t('updater.failed'),
+            message: detail,
+            buttons: [t('updater.ok')],
+            defaultId: 0,
+        };
+        const parentWindow = getMainWindow();
+        if (parentWindow && !parentWindow.isDestroyed()) {
+            void dialog.showMessageBox(parentWindow, options);
+        } else {
+            void dialog.showMessageBox(options);
+        }
+    }
 }
 
 function showInstallLocationBlockedDialog(t: MainTranslator) {
@@ -394,7 +419,7 @@ function handleUpdateAction(log: LogFn, t: MainTranslator, action: UpdateAction)
             downloadInProgress = true;
             autoUpdater.downloadUpdate().catch((error: unknown) => {
                 downloadInProgress = false;
-                showUpdateError(log, error);
+                showUpdateError(log, t, error, true);
             });
             break;
         }
@@ -444,7 +469,7 @@ function handleUpdateAction(log: LogFn, t: MainTranslator, action: UpdateAction)
                 restartInstallInFlight = false;
                 setMainWindowQuitting(false);
                 log('[updater] quitAndInstall failed:', error);
-                showUpdateError(log, error);
+                showUpdateError(log, t, error, true);
             }
             break;
         }
@@ -651,6 +676,12 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
             return;
         }
 
+        const remindUntil = updaterPreferenceStore.get('remindLaterUntil');
+        if (remindUntil && Date.now() < remindUntil) {
+            log('[updater] remind-later still active, suppress auto download until:', new Date(remindUntil).toISOString());
+            return;
+        }
+
         // Auto checks should always fetch the update package in background so renderer can show
         // "ready to install" state without extra user action.
         log('[updater] auto check found update, start silent background download');
@@ -661,7 +692,7 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
             downloadInProgress = false;
             shouldAutoInstallAfterDownload = false;
             showDownloadProgressDialog = false;
-            showUpdateError(logError, error);
+            showUpdateError(logError, t, error, false);
         });
     });
 
@@ -714,6 +745,7 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
     autoUpdater.on('error', (error: Error) => {
         debugPreviewMode = false;
         stopDebugProgressTimer();
+        const wasManual = isManualCheck;
         checkInProgress = false;
         downloadInProgress = false;
         downloadCanceledByUser = false;
@@ -722,7 +754,7 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
         isManualCheck = false;
         availableVersion = null;
         closeAllDialogs();
-        showUpdateError(logError, error);
+        showUpdateError(logError, t, error, wasManual);
     });
 
     app.on('before-quit', () => {
@@ -736,6 +768,19 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
         if (checkInProgress || downloadInProgress) {
             if (manual) {
                 logWarn('[updater] check ignored: update flow already in progress');
+                const options: MessageBoxOptions = {
+                    type: 'info',
+                    title: t('updater.title'),
+                    message: t('updater.updateInProgress'),
+                    buttons: [t('updater.ok')],
+                    defaultId: 0,
+                };
+                const parentWindow = getMainWindow();
+                if (parentWindow && !parentWindow.isDestroyed()) {
+                    void dialog.showMessageBox(parentWindow, options);
+                } else {
+                    void dialog.showMessageBox(options);
+                }
             }
             return;
         }
@@ -757,7 +802,7 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
             isManualCheck = false;
             availableVersion = null;
             closeAllDialogs();
-            showUpdateError(logError, error);
+            showUpdateError(logError, t, error, manual);
         } finally {
             showCheckingDialog = false;
         }


### PR DESCRIPTION
## Summary

- **Manual check error feedback**: `showUpdateError` now displays a categorized error dialog (network / server / generic) when triggered by a manual "Check for Updates", instead of silently swallowing all errors. Reuses existing but previously unused i18n keys (`checkFailedNetwork`, `checkFailedServer`, `checkFailedGeneric`).
- **In-progress guard feedback**: When a manual check is blocked by an ongoing check or download, shows an info dialog instead of silently returning. Adds new `updater.updateInProgress` i18n key (zh-CN / en-US).
- **Fix `remindLaterUntil` dead code**: The "Remind Me Later" preference was written but never read back. Now auto-checks respect the 24h remind-later window and suppress silent background downloads until it expires. Manual checks are unaffected.
- **Preserve `isManualCheck` in error event**: The `autoUpdater.on('error')` handler now captures `isManualCheck` before resetting state, so errors from manual checks correctly show a dialog.

## Test plan

- [ ] Click "Check for Updates" with network disconnected — should show network error dialog
- [ ] Click "Check for Updates" while a background download is in progress — should show "update in progress" dialog
- [ ] Click "Remind Me Later" on an update prompt — auto-check within 24h should not silently download
- [ ] Click "Check for Updates" after "Remind Me Later" — should still show the update prompt (manual check unaffected)
- [ ] Verify zh-CN and en-US locales both display correct text