### PR TITLE
fix: prevent duplicate error dialogs on update check failure

### DIFF
--- a/apps/electron/main/updater.ts
+++ b/apps/electron/main/updater.ts
@@ -745,7 +745,6 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
     autoUpdater.on('error', (error: Error) => {
         debugPreviewMode = false;
         stopDebugProgressTimer();
-        const wasManual = isManualCheck;
         checkInProgress = false;
         downloadInProgress = false;
         downloadCanceledByUser = false;
@@ -754,7 +753,9 @@ export function setupUpdater({ log, logWarn, logError, locale, t }: SetupUpdater
         isManualCheck = false;
         availableVersion = null;
         closeAllDialogs();
-        showUpdateError(logError, t, error, wasManual);
+        // Dialog is handled by the catch block at each call site (runCheckForUpdates,
+        // downloadUpdate, etc.) to avoid duplicate dialogs, so always pass manual=false here.
+        showUpdateError(logError, t, error, false);
     });
 
     app.on('before-quit', () => {


### PR DESCRIPTION
## Summary

- The `autoUpdater` `error` event and the `catch` block at each call site (`runCheckForUpdates`, `downloadUpdate`) both fire on failure, causing two identical error dialogs to appear when a manual update check fails.
- Fix: the `error` event handler now always passes `manual=false` to `showUpdateError`, delegating user-facing dialogs to the specific `catch` blocks which already handle them correctly.

## Test plan

- [ ] Click "Check for Updates" with no network — should show exactly one error dialog
- [ ] Click "Install Update" and let the download fail — should show exactly one error dialog
- [ ] Auto-check failure (background) — should not show any dialog