### PR TITLE
feat: add workspace export and import

### DIFF
--- a/apps/web/app/(app)/components/settings/DataPanel.tsx
+++ b/apps/web/app/(app)/components/settings/DataPanel.tsx
@@ -1,5 +1,139 @@
-import { ComingSoonPanel } from './ComingSoonPanel';
+'use client';
+
+import { useRef, useState } from 'react';
+import { Download, Upload, Loader2 } from 'lucide-react';
+import { Button } from '@/registry/new-york-v4/ui/button';
+import { SettingsRow } from './SettingsRow';
+import { authFetch } from '@/lib/client/auth-fetch';
+
+type ImportResult = {
+    connections: { created: number; skipped: number };
+    savedQueryFolders: { created: number };
+    savedQueries: { created: number; skipped: number };
+};
 
 export function DataPanel() {
-    return <ComingSoonPanel />;
+    const [exporting, setExporting] = useState(false);
+    const [importing, setImporting] = useState(false);
+    const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleExport = async () => {
+        setExporting(true);
+        setMessage(null);
+        try {
+            const res = await authFetch('/api/workspace/export');
+            const json = await res.json();
+            if (json.code !== 0) {
+                setMessage({ type: 'error', text: json.message ?? 'Export failed' });
+                return;
+            }
+
+            const blob = new Blob([JSON.stringify(json.data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `dory-workspace-${new Date().toISOString().slice(0, 10)}.json`;
+            a.click();
+            setTimeout(() => URL.revokeObjectURL(url), 5000);
+            setMessage({ type: 'success', text: 'Workspace exported successfully.' });
+        } catch {
+            setMessage({ type: 'error', text: 'Export failed. Please try again.' });
+        } finally {
+            setExporting(false);
+        }
+    };
+
+    const handleImport = () => {
+        fileInputRef.current?.click();
+    };
+
+    const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        // Reset input so the same file can be selected again
+        e.target.value = '';
+
+        setImporting(true);
+        setMessage(null);
+        try {
+            const text = await file.text();
+            let data: unknown;
+            try {
+                data = JSON.parse(text);
+            } catch {
+                setMessage({ type: 'error', text: 'Invalid JSON file.' });
+                return;
+            }
+
+            const res = await authFetch('/api/workspace/import', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
+            const json = await res.json();
+            if (json.code !== 0) {
+                setMessage({ type: 'error', text: json.message ?? 'Import failed' });
+                return;
+            }
+
+            const r = json.data as ImportResult;
+            const parts: string[] = [];
+            if (r.connections.created > 0) parts.push(`${r.connections.created} connection(s)`);
+            if (r.savedQueryFolders.created > 0) parts.push(`${r.savedQueryFolders.created} folder(s)`);
+            if (r.savedQueries.created > 0) parts.push(`${r.savedQueries.created} query(ies)`);
+            if (r.savedQueries.skipped > 0) parts.push(`${r.savedQueries.skipped} query(ies) skipped`);
+
+            const summary = parts.length > 0 ? `Imported: ${parts.join(', ')}.` : 'Nothing to import.';
+            setMessage({ type: 'success', text: summary });
+        } catch {
+            setMessage({ type: 'error', text: 'Import failed. Please try again.' });
+        } finally {
+            setImporting(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <SettingsRow
+                label="Export Workspace"
+                description="Download connections and saved queries as a JSON file. Passwords and keys are excluded."
+            >
+                <Button variant="outline" size="sm" onClick={handleExport} disabled={exporting}>
+                    {exporting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Download className="mr-2 h-4 w-4" />}
+                    Export
+                </Button>
+            </SettingsRow>
+
+            <SettingsRow
+                label="Import Workspace"
+                description="Import connections and saved queries from a previously exported JSON file."
+            >
+                <Button variant="outline" size="sm" onClick={handleImport} disabled={importing}>
+                    {importing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+                    Import
+                </Button>
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".json"
+                    className="hidden"
+                    onChange={handleFileSelected}
+                />
+            </SettingsRow>
+
+            {message && (
+                <div
+                    className={`text-sm px-3 py-2 rounded-md ${
+                        message.type === 'success'
+                            ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+                            : 'bg-destructive/10 text-destructive'
+                    }`}
+                >
+                    {message.text}
+                </div>
+            )}
+        </div>
+    );
 }

--- a/apps/web/app/(app)/components/settings/types.ts
+++ b/apps/web/app/(app)/components/settings/types.ts
@@ -1,5 +1,5 @@
 import type { ElementType } from 'react';
-import { Palette, Keyboard, Info, Code } from 'lucide-react';
+import { Palette, Keyboard, Info, Code, Database } from 'lucide-react';
 
 export type CategoryKey =
     | 'appearance'
@@ -33,6 +33,13 @@ export const CATEGORIES: Array<{
         title: 'Editor Settings',
         description: 'Customize the SQL editor appearance and behavior.',
         tag: 'SQL',
+    },
+    {
+        key: 'data',
+        label: 'Data',
+        icon: Database,
+        title: 'Data Management',
+        description: 'Export and import workspace data.',
     },
     // { key: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
     {

--- a/apps/web/app/api/workspace/export/route.ts
+++ b/apps/web/app/api/workspace/export/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { ResponseUtil } from '@/lib/result';
+import { withUserAndTeamHandler } from '../../utils/with-team-handler';
+import { handleApiError } from '../../utils/handle-error';
+
+export const GET = withUserAndTeamHandler(async ({ db, teamId, userId }) => {
+    try {
+        // Fetch connections (team-level)
+        const connectionList = await db.connections.list(teamId);
+
+        // Fetch saved query folders (user-level)
+        const folders = await db.savedQueryFolders.list({ teamId, userId });
+
+        // Fetch all saved queries across all connections (user-level)
+        const queries = await db.savedQueries.listAll({ teamId, userId });
+
+        // Build connection name map: connectionId -> connectionName
+        const connectionNameMap = new Map<string, string>();
+        for (const item of connectionList) {
+            connectionNameMap.set(item.connection.id, item.connection.name);
+        }
+
+        // Build folder export ID map: folderId -> exportIndex
+        const folderExportIdMap = new Map<string, string>();
+        folders.forEach((f, i) => {
+            folderExportIdMap.set(f.id, `folder_${i}`);
+        });
+
+        // Export connections (exclude sensitive data)
+        const exportedConnections = connectionList.map(item => ({
+            connection: {
+                type: item.connection.type,
+                engine: item.connection.engine,
+                name: item.connection.name,
+                description: item.connection.description ?? null,
+                host: item.connection.host,
+                port: item.connection.port,
+                httpPort: item.connection.httpPort ?? null,
+                database: item.connection.database ?? null,
+                options: item.connection.options,
+                environment: item.connection.environment,
+                tags: item.connection.tags,
+            },
+            identities: item.identities.map(id => ({
+                name: id.name,
+                username: id.username,
+                role: id.role,
+                isDefault: id.isDefault,
+                database: id.database,
+            })),
+            ssh: item.ssh
+                ? {
+                      enabled: item.ssh.enabled,
+                      host: item.ssh.host,
+                      port: item.ssh.port,
+                      username: item.ssh.username,
+                      authMethod: item.ssh.authMethod,
+                  }
+                : null,
+        }));
+
+        // Export folders
+        const exportedFolders = folders.map(f => ({
+            _exportId: folderExportIdMap.get(f.id)!,
+            name: f.name,
+            position: f.position,
+        }));
+
+        // Export queries
+        const exportedQueries = queries.map(q => ({
+            title: q.title,
+            description: q.description ?? null,
+            sqlText: q.sqlText,
+            connectionName: connectionNameMap.get(q.connectionId) ?? null,
+            context: q.context ?? {},
+            tags: q.tags ?? [],
+            folderExportId: q.folderId ? (folderExportIdMap.get(q.folderId) ?? null) : null,
+            position: q.position,
+        }));
+
+        const exportData = {
+            version: 1,
+            exportedAt: new Date().toISOString(),
+            connections: exportedConnections,
+            savedQueryFolders: exportedFolders,
+            savedQueries: exportedQueries,
+        };
+
+        return NextResponse.json(ResponseUtil.success(exportData));
+    } catch (err: any) {
+        return handleApiError(err);
+    }
+});

--- a/apps/web/app/api/workspace/import/route.ts
+++ b/apps/web/app/api/workspace/import/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { ResponseUtil } from '@/lib/result';
+import { ErrorCodes } from '@/lib/errors';
+import { withUserAndTeamHandler } from '../../utils/with-team-handler';
+import { handleApiError } from '../../utils/handle-error';
+import { parseJsonBody } from '../../utils/parse-json';
+
+const identitySchema = z.object({
+    name: z.string().min(1),
+    username: z.string().min(1),
+    role: z.string().nullable().optional(),
+    isDefault: z.boolean().optional(),
+    database: z.string().nullable().optional(),
+});
+
+const sshSchema = z.object({
+    enabled: z.boolean(),
+    host: z.string().nullable().optional(),
+    port: z.number().nullable().optional(),
+    username: z.string().nullable().optional(),
+    authMethod: z.string().nullable().optional(),
+});
+
+const connectionSchema = z.object({
+    connection: z.object({
+        type: z.string().min(1),
+        engine: z.string().min(1),
+        name: z.string().min(1),
+        description: z.string().nullable().optional(),
+        host: z.string().min(1),
+        port: z.number().int().min(1).max(65535),
+        httpPort: z.number().int().min(1).max(65535).nullable().optional(),
+        database: z.string().nullable().optional(),
+        options: z.string().optional(),
+        environment: z.string().optional(),
+        tags: z.string().optional(),
+    }),
+    identities: z.array(identitySchema).optional(),
+    ssh: sshSchema.nullable().optional(),
+});
+
+const folderSchema = z.object({
+    _exportId: z.string(),
+    name: z.string().min(1),
+    position: z.number().int().optional(),
+});
+
+const querySchema = z.object({
+    title: z.string().min(1),
+    description: z.string().nullable().optional(),
+    sqlText: z.string().min(1),
+    connectionName: z.string().nullable().optional(),
+    context: z.record(z.string(), z.unknown()).optional(),
+    tags: z.array(z.string()).optional(),
+    folderExportId: z.string().nullable().optional(),
+    position: z.number().int().optional(),
+});
+
+const importSchema = z.object({
+    version: z.number().int().min(1).max(1),
+    exportedAt: z.string().optional(),
+    connections: z.array(connectionSchema).optional(),
+    savedQueryFolders: z.array(folderSchema).optional(),
+    savedQueries: z.array(querySchema).optional(),
+});
+
+function formatTimeSuffix(): string {
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+}
+
+async function resolveUniqueConnectionName(
+    existingNames: Set<string>,
+    desiredName: string,
+): Promise<string> {
+    if (!existingNames.has(desiredName)) return desiredName;
+    const suffix = `(import ${formatTimeSuffix()})`;
+    let candidate = `${desiredName} ${suffix}`;
+    let counter = 2;
+    while (existingNames.has(candidate)) {
+        candidate = `${desiredName} ${suffix} ${counter}`;
+        counter++;
+    }
+    return candidate;
+}
+
+export const POST = withUserAndTeamHandler(async ({ req, db, teamId, userId }) => {
+    try {
+        const payload = await parseJsonBody(req, importSchema);
+
+        const result = {
+            connections: { created: 0, skipped: 0 },
+            savedQueryFolders: { created: 0 },
+            savedQueries: { created: 0, skipped: 0 },
+        };
+
+        // 1. Get existing connection names
+        const existingConnections = await db.connections.list(teamId);
+        const existingNames = new Set(existingConnections.map(c => c.connection.name));
+
+        // Map: original export name -> new connectionId
+        const connectionNameToIdMap = new Map<string, string>();
+
+        // Also include existing connections in the map
+        for (const c of existingConnections) {
+            connectionNameToIdMap.set(c.connection.name, c.connection.id);
+        }
+
+        // 2. Import connections
+        if (payload.connections) {
+            for (const item of payload.connections) {
+                const resolvedName = await resolveUniqueConnectionName(existingNames, item.connection.name);
+                existingNames.add(resolvedName);
+
+                const created = await db.connections.create(userId, teamId, {
+                    connection: {
+                        ...item.connection,
+                        name: resolvedName,
+                        teamId,
+                    } as any,
+                    identities: (item.identities ?? []) as any,
+                    ssh: item.ssh as any,
+                });
+
+                connectionNameToIdMap.set(item.connection.name, created.connection.id);
+                result.connections.created++;
+            }
+        }
+
+        // 3. Import folders
+        const folderExportIdToNewIdMap = new Map<string, string>();
+
+        if (payload.savedQueryFolders) {
+            for (const folder of payload.savedQueryFolders) {
+                const created = await db.savedQueryFolders.create({
+                    teamId,
+                    userId,
+                    name: folder.name,
+                });
+                folderExportIdToNewIdMap.set(folder._exportId, created.id);
+                result.savedQueryFolders.created++;
+            }
+        }
+
+        // 4. Import saved queries
+        if (payload.savedQueries) {
+            for (const query of payload.savedQueries) {
+                // Resolve connectionId from connectionName
+                const connectionId = query.connectionName
+                    ? connectionNameToIdMap.get(query.connectionName)
+                    : null;
+
+                if (!connectionId) {
+                    result.savedQueries.skipped++;
+                    continue;
+                }
+
+                // Resolve folderId
+                const folderId = query.folderExportId
+                    ? (folderExportIdToNewIdMap.get(query.folderExportId) ?? null)
+                    : null;
+
+                const created = await db.savedQueries.create({
+                    teamId,
+                    userId,
+                    title: query.title,
+                    description: query.description,
+                    sqlText: query.sqlText,
+                    context: query.context as Record<string, unknown>,
+                    tags: query.tags,
+                    connectionId,
+                });
+
+                // Update folderId and position if needed
+                if (folderId || query.position) {
+                    await db.savedQueries.update({
+                        teamId,
+                        userId,
+                        id: created.id,
+                        connectionId,
+                        patch: {
+                            ...(folderId ? { folderId } : {}),
+                            ...(query.position ? { position: query.position } : {}),
+                        },
+                    });
+                }
+
+                result.savedQueries.created++;
+            }
+        }
+
+        return NextResponse.json(ResponseUtil.success(result));
+    } catch (err: any) {
+        if (err instanceof z.ZodError) {
+            return NextResponse.json(
+                ResponseUtil.error({
+                    code: ErrorCodes.VALIDATION_ERROR,
+                    message: 'Invalid import data format',
+                    error: err,
+                }),
+                { status: 400 },
+            );
+        }
+        return handleApiError(err);
+    }
+});

--- a/apps/web/lib/database/postgres/impl/connections/index.ts
+++ b/apps/web/lib/database/postgres/impl/connections/index.ts
@@ -105,6 +105,7 @@ export class PostgresConnectionsRepository {
                 environment: row.environment,
                 tags: row.tags,
                 lastUsedAt: row.lastUsedAt,
+                database: row.database,
             });
         }
 

--- a/apps/web/lib/database/postgres/impl/sql-console/save-queries/index.ts
+++ b/apps/web/lib/database/postgres/impl/sql-console/save-queries/index.ts
@@ -151,6 +151,24 @@ export class PostgresSavedQueriesRepository {
         return (row as SavedQueryRecord | undefined) ?? null;
     }
 
+    async listAll(params: { teamId: string; userId: string }): Promise<SavedQueryRecord[]> {
+        this.assertInited();
+
+        const rows = await this.db
+            .select()
+            .from(savedQueries)
+            .where(
+                and(
+                    eq(savedQueries.teamId, params.teamId),
+                    eq(savedQueries.userId, params.userId),
+                    isNull(savedQueries.archivedAt),
+                ),
+            )
+            .orderBy(asc(savedQueries.position), desc(savedQueries.updatedAt));
+
+        return rows as SavedQueryRecord[];
+    }
+
     async list(params: SavedQueryListParams): Promise<SavedQueryRecord[]> {
         this.assertInited();
 


### PR DESCRIPTION
## Summary

Closes #66

- Add **Export Workspace** and **Import Workspace** functionality under Settings > Data panel
- Export includes connections (team-level), saved queries and folders (user-level) as a downloadable JSON file
- Sensitive data (passwords, SSH keys, tokens) are excluded from export
- Import validates JSON schema (version, required fields, port range, etc.)
- Duplicate connection names are auto-renamed with timestamp suffix, e.g. `My DB (import 2026-03-18 14:30:25)`
- Queries referencing non-existent connections are skipped with count reported
- Import result summary shows created/skipped counts for connections, folders, and queries

### Files changed

| File | Change |
|------|--------|
| `app/api/workspace/export/route.ts` | New - GET endpoint to export workspace |
| `app/api/workspace/import/route.ts` | New - POST endpoint to import workspace with validation |
| `app/(app)/components/settings/DataPanel.tsx` | Replaced ComingSoonPanel with Export/Import UI |
| `app/(app)/components/settings/types.ts` | Enabled Data category in settings sidebar |
| `lib/database/postgres/impl/sql-console/save-queries/index.ts` | Added `listAll` method for cross-connection query listing |
| `lib/database/postgres/impl/connections/index.ts` | Fixed missing `database` field in `list` mapping |

## Test plan

- [x] Export with connections, folders, and saved queries - verified JSON output is complete
- [x] Export excludes passwords and SSH keys
- [x] Import creates connections, folders, and queries correctly
- [x] Duplicate connection names get timestamp suffix
- [x] Query-to-connection and query-to-folder associations preserved after import
- [x] Re-export after import includes all imported data
- [x] Invalid JSON / missing version / bad version rejected with proper error
- [x] Missing required fields (host, port) rejected
- [x] Invalid port range (>65535) rejected
- [x] Orphan queries (connectionName not found) skipped with count
- [x] Bad folder references handled gracefully (query created without folder)
- [x] Empty import succeeds with zero counts
- [x] UI Export button triggers file download and shows success message