### PR TITLE
fix: use node:lts-slim to reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN yarn run build \
  && cp -rn node_modules/@electric-sql/pglite/dist/. apps/web/dist-scripts/ \
  && rm -f apps/web/.next/standalone/.env apps/web/.next/standalone/.env.local
 
-FROM node:lts AS runner
+FROM node:lts-slim AS runner
 
 ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \


### PR DESCRIPTION
## Summary
- Changed the base image of the runner stage from `node:lts` to `node:lts-slim`, removing unnecessary build toolchains at runtime (e.g., gcc, g++, imagemagick)
- Reduced image size from ~1.5GB to ~575MB (~60% reduction)

## Test plan
- [x] `docker build -t dory-test:latest .` builds successfully
- [ ] Verify the container starts and runs correctly