### PR TITLE
fix: avoid Turbopack overly broad file tracing warning in pglite client

### DIFF
--- a/apps/web/lib/database/postgres/client/pglite.ts
+++ b/apps/web/lib/database/postgres/client/pglite.ts
@@ -34,8 +34,9 @@ async function resolvePgliteDataDir(): Promise<string> {
 
     // 3) Fallback (e.g. local Node debugging)
     const defaultDir = isDesktopRuntime() ? DESKTOP_PGLITE_DB_PATH : DEFAULT_PGLITE_DB_PATH;
-    const dir = path.resolve(process.cwd(), defaultDir);
-    return dir;
+    // Indirect call to prevent Turbopack from statically tracing this as a file pattern
+    const resolve = path.resolve.bind(path);
+    return resolve(process.cwd(), defaultDir);
 }
 
 async function initPglite(): Promise<PostgresDBClient> {


### PR DESCRIPTION
## Summary

- Turbopack statically analyzes `path.resolve()` calls for file tracing during builds. The call `path.resolve(process.cwd(), defaultDir)` in `pglite.ts` caused Turbopack to conservatively match **13,032 files** under `apps/web/`, triggering an "overly broad patterns" warning.
- Since this path is only used at runtime to locate the PGlite data directory (not a module import), use an indirect call via `path.resolve.bind(path)` to prevent Turbopack's static analysis from tracing it.

## Test plan

- [x] Verified Docker build **without** the fix produces the Turbopack warning
- [x] Verified Docker build **with** the fix completes successfully with no warnings
- [x] Verified local `yarn run build` passes