### PR TITLE
feat: add Homebrew tap auto-update workflow

### DIFF
--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -92,6 +92,10 @@ jobs:
         runs-on: macos-latest
         environment: ${{ needs.resolve_context.outputs.environment_name }}
 
+        strategy:
+            matrix:
+                arch: [arm64, x64]
+
         env:
             GH_TOKEN: ${{ github.token }}
 
@@ -179,7 +183,7 @@ jobs:
                   NEXT_PUBLIC_DORY_CLOUD_API_URL=$NEXT_PUBLIC_DORY_CLOUD_API_URL
                   EOF
 
-            - name: Build Electron app (mac)
+            - name: Build Electron app (mac ${{ matrix.arch }})
               env:
                   CSC_LINK: ${{ secrets.APPLE_CERT_BASE64 }}
                   CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
@@ -189,12 +193,15 @@ jobs:
                   DORY_APP_BASE_URL: ${{ steps.build_config.outputs.app_base_url }}
                   DORY_ELECTRON_APP_ID: ${{ steps.build_config.outputs.electron_app_id }}
                   DORY_PROTOCOL_SCHEME: ${{ steps.build_config.outputs.protocol_scheme }}
-              run: yarn electron:build:apple
+              run: |
+                  yarn run electron:standalone
+                  cd apps/electron
+                  npx electron-builder --config electron-builder.mjs --mac --${{ matrix.arch }} --publish never
 
             - name: Upload workflow artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: ${{ needs.resolve_context.outputs.distribution == 'beta' && 'electron-macos-beta-dist' || 'electron-macos-dist' }}
+                  name: ${{ needs.resolve_context.outputs.distribution == 'beta' && format('electron-macos-beta-{0}-dist', matrix.arch) || format('electron-macos-{0}-dist', matrix.arch) }}
                   path: apps/electron/dist/*
                   if-no-files-found: error
 
@@ -218,9 +225,16 @@ jobs:
                   find apps/electron/dist -maxdepth 1 -type f -name "${CHANNEL}*.yml" \
                     -print0 | xargs -0 -I {} gh release upload "$TAG" "{}" --clobber
 
+    update-homebrew:
+        needs: [resolve_context, package]
+        if: needs.resolve_context.outputs.tag != '' && needs.resolve_context.outputs.distribution == 'stable'
+        runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ github.token }}
+        steps:
             - name: Dispatch Homebrew tap update
-              if: needs.resolve_context.outputs.tag != '' && needs.resolve_context.outputs.distribution == 'stable'
               run: |
-                  gh workflow run ".github/workflows/update-homebrew.yml" \
+                  gh workflow run "update-homebrew.yml" \
+                    --repo "${{ github.repository }}" \
                     --ref "${{ github.ref_name }}" \
                     -f tag="${{ needs.resolve_context.outputs.tag }}"

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -40,25 +40,37 @@ jobs:
                   echo "Using tag: $VERSION"
                   echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
 
-            - name: Download macOS DMG and compute checksum
+            - name: Download macOS DMGs and compute checksums
               id: checksum
               run: |
                   set -euo pipefail
                   VERSION="${{ steps.validate-tag.outputs.tag }}"
                   VERSION_NUM="${VERSION#v}"
                   BASE_URL="https://github.com/${{ github.repository }}/releases/download/${VERSION}"
-                  DMG_NAME="Dory-${VERSION_NUM}-arm64.dmg"
 
-                  curl -fsSL "${BASE_URL}/${DMG_NAME}" -o "${DMG_NAME}"
-                  SHA256=$(sha256sum "${DMG_NAME}" | cut -d' ' -f1)
+                  ARM64_DMG="Dory-${VERSION_NUM}-arm64.dmg"
+                  X64_DMG="Dory-${VERSION_NUM}-x64.dmg"
 
-                  if [[ ! "$SHA256" =~ ^[0-9a-fA-F]{64}$ ]]; then
-                    echo "Error: invalid checksum: $SHA256"
+                  curl -fsSL "${BASE_URL}/${ARM64_DMG}" -o "${ARM64_DMG}"
+                  ARM64_SHA=$(sha256sum "${ARM64_DMG}" | cut -d' ' -f1)
+
+                  curl -fsSL "${BASE_URL}/${X64_DMG}" -o "${X64_DMG}"
+                  X64_SHA=$(sha256sum "${X64_DMG}" | cut -d' ' -f1)
+
+                  if [[ ! "$ARM64_SHA" =~ ^[0-9a-fA-F]{64}$ ]]; then
+                    echo "Error: invalid arm64 checksum: $ARM64_SHA"
                     exit 1
                   fi
 
-                  echo "SHA256: $SHA256"
-                  echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+                  if [[ ! "$X64_SHA" =~ ^[0-9a-fA-F]{64}$ ]]; then
+                    echo "Error: invalid x64 checksum: $X64_SHA"
+                    exit 1
+                  fi
+
+                  echo "ARM64 SHA256: $ARM64_SHA"
+                  echo "X64 SHA256: $X64_SHA"
+                  echo "arm64_sha=$ARM64_SHA" >> "$GITHUB_OUTPUT"
+                  echo "x64_sha=$X64_SHA" >> "$GITHUB_OUTPUT"
 
             - name: Update Homebrew Cask
               env:
@@ -67,12 +79,10 @@ jobs:
                   set -euo pipefail
                   VERSION="${{ steps.validate-tag.outputs.tag }}"
                   VERSION_NUM="${VERSION#v}"
-                  SHA256="${{ steps.checksum.outputs.sha256 }}"
+                  ARM64_SHA="${{ steps.checksum.outputs.arm64_sha }}"
+                  X64_SHA="${{ steps.checksum.outputs.x64_sha }}"
 
-                  git clone "https://git:${GH_TOKEN}@github.com/dorylab/homebrew-dory.git"
-                  cd homebrew-dory
-
-                  cat > Casks/dory.rb <<'CASK_EOF'
+                  cat > dory.rb <<'CASK_EOF'
                   cask "dory" do
                     version "VERSION_PLACEHOLDER"
 
@@ -80,10 +90,13 @@ jobs:
                     desc "The database manager for modern developers"
                     homepage "https://github.com/dorylab/dory"
 
-                    url "https://github.com/dorylab/dory/releases/download/v#{version}/Dory-#{version}-arm64.dmg"
-                    sha256 "SHA256_PLACEHOLDER"
-
-                    depends_on arch: :arm64
+                    if Hardware::CPU.intel?
+                      url "https://github.com/dorylab/dory/releases/download/v#{version}/Dory-#{version}-x64.dmg"
+                      sha256 "X64_SHA_PLACEHOLDER"
+                    else
+                      url "https://github.com/dorylab/dory/releases/download/v#{version}/Dory-#{version}-arm64.dmg"
+                      sha256 "ARM64_SHA_PLACEHOLDER"
+                    end
 
                     app "Dory.app"
 
@@ -95,9 +108,14 @@ jobs:
                   end
                   CASK_EOF
 
-                  sed -i "s/VERSION_PLACEHOLDER/${VERSION_NUM}/" Casks/dory.rb
-                  sed -i "s/SHA256_PLACEHOLDER/${SHA256}/" Casks/dory.rb
+                  sed -i "s/VERSION_PLACEHOLDER/${VERSION_NUM}/" dory.rb
+                  sed -i "s/ARM64_SHA_PLACEHOLDER/${ARM64_SHA}/" dory.rb
+                  sed -i "s/X64_SHA_PLACEHOLDER/${X64_SHA}/" dory.rb
 
+                  git clone "https://git:${GH_TOKEN}@github.com/dorylab/homebrew-dory.git"
+                  cp dory.rb homebrew-dory/Casks/dory.rb
+
+                  cd homebrew-dory
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add Casks/dory.rb


### PR DESCRIPTION
## Summary
- Add `update-homebrew.yml` reusable workflow for auto-updating `dorylab/homebrew-dory` cask
- Dispatch homebrew tap update from `macos-package.yml` after stable release assets are uploaded
- Supports both `workflow_dispatch` (manual) and `workflow_call` (from other workflows)

## Test plan
- [ ] Merge to main and manually trigger: `gh workflow run update-homebrew.yml -f tag=v0.4.10`
- [ ] Verify `dorylab/homebrew-dory` Casks/dory.rb is updated with correct version and sha256