### PR TITLE
feat: introduce Automation API (#116)

### DIFF
--- a/apps/web/app/api/automation/ai/ask/route.ts
+++ b/apps/web/app/api/automation/ai/ask/route.ts
@@ -1,0 +1,191 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { tool, stepCountIs } from 'ai';
+import { ErrorCodes } from '@/lib/errors';
+import { ResponseUtil } from '@/lib/result';
+import { generateText } from '@/lib/ai/gateway';
+import { getEffectiveModelBundle } from '@/lib/ai/model';
+import { buildSchemaContext, getDefaultSchemaSampleLimits } from '@/lib/ai/prompts/contexts/schema';
+import { SYSTEM_PROMPT } from '@/lib/ai/prompts/system/core';
+import { ensureConnectionPoolForUser } from '@/app/api/connection/utils';
+import { isMissingAiEnvError } from '@/lib/ai/errors';
+import { withAutomationHandler } from '../../with-automation-handler';
+import { isReadOnlyQuery, AI_ROW_LIMIT } from '../../utils';
+
+/**
+ * POST /api/automation/ai/ask
+ *
+ * Ask a natural language question about your data.
+ * AI will generate SQL, execute it, and return the answer.
+ *
+ * Body:
+ * {
+ *   "connectionId": "xxx",
+ *   "question": "Top 10 slow queries yesterday",
+ *   "database": "mydb"    // optional
+ * }
+ */
+export const POST = withAutomationHandler(async ({ req, userId, organizationId }) => {
+    const body = await req.json();
+    const { connectionId, question, database } = body;
+
+    if (!connectionId) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.INVALID_PARAMS,
+                message: 'Missing required field: connectionId',
+            }),
+            { status: 400 },
+        );
+    }
+
+    if (!question || typeof question !== 'string' || !question.trim()) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.INVALID_PARAMS,
+                message: 'Missing required field: question',
+            }),
+            { status: 400 },
+        );
+    }
+
+    // Verify connection exists and is accessible
+    try {
+        await ensureConnectionPoolForUser(userId, organizationId, connectionId, null);
+    } catch {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.NOT_FOUND,
+                message: 'Connection not found or could not be established.',
+            }),
+            { status: 404 },
+        );
+    }
+
+    // Build schema context for AI
+    const defaults = getDefaultSchemaSampleLimits();
+    const schemaContext = await buildSchemaContext({
+        userId,
+        organizationId,
+        datasourceId: connectionId,
+        database,
+        tableSampleLimit: defaults.table,
+        columnSampleLimit: defaults.column,
+    });
+
+    // Build SQL runner tool for AI to use
+    const sqlResults: Array<{ sql: string; rows: unknown[]; columns: unknown; rowCount: number; error?: string }> = [];
+
+    const sqlRunner = tool({
+        description: 'Execute a read-only SQL query against the database and return the results.',
+        inputSchema: z.object({
+            sql: z.string().min(1, 'SQL query is required'),
+            database: z.string().optional(),
+        }),
+        execute: async ({ sql, database: db }) => {
+            const trimmed = sql.trim();
+            if (!isReadOnlyQuery(trimmed)) {
+                const errorResult = {
+                    ok: false,
+                    error: 'Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed.',
+                    sql: trimmed,
+                };
+                sqlResults.push({ sql: trimmed, rows: [], columns: null, rowCount: 0, error: errorResult.error });
+                return errorResult;
+            }
+
+            try {
+                const { entry } = await ensureConnectionPoolForUser(userId, organizationId, connectionId, null);
+                const result = await entry.instance.queryWithContext(trimmed, {
+                    database: db ?? database,
+                });
+
+                const rows = Array.isArray(result.rows) ? result.rows.slice(0, AI_ROW_LIMIT) : [];
+                const columns = result.columns ?? null;
+                const rowCount = result.rowCount ?? rows.length;
+
+                sqlResults.push({ sql: trimmed, rows, columns, rowCount });
+
+                return {
+                    ok: true,
+                    columns,
+                    rows,
+                    rowCount,
+                    limited: rows.length >= AI_ROW_LIMIT,
+                };
+            } catch (err: any) {
+                const errorMsg = String(err?.message || err);
+                sqlResults.push({ sql: trimmed, rows: [], columns: null, rowCount: 0, error: errorMsg });
+                return {
+                    ok: false,
+                    error: errorMsg,
+                    sql: trimmed,
+                };
+            }
+        },
+    });
+
+    // Build system prompt
+    const schemaSection = schemaContext ? `\nSchema Context:\n${schemaContext}` : '';
+    const systemPrompt = [
+        SYSTEM_PROMPT.trim(),
+        'You have access to a sqlRunner tool to execute read-only SQL queries.',
+        'When the user asks a data question, generate appropriate SQL and execute it using the tool.',
+        'After getting results, provide a clear, concise answer based on the data.',
+        schemaSection,
+    ]
+        .filter(Boolean)
+        .join('\n\n');
+
+    try {
+        const { model, modelName } = getEffectiveModelBundle('chat');
+
+        const result = await generateText({
+            model,
+            system: systemPrompt,
+            messages: [{ role: 'user' as const, content: question.trim() }],
+            tools: { sqlRunner },
+            toolChoice: 'auto',
+            stopWhen: stepCountIs(4),
+            context: {
+                organizationId,
+                userId,
+                feature: 'automation_ai_ask',
+                model: modelName,
+            },
+        });
+
+        return NextResponse.json(
+            ResponseUtil.success({
+                answer: result.text,
+                sqlResults,
+                usage: result.usage
+                    ? {
+                          inputTokens: result.usage.inputTokens,
+                          outputTokens: result.usage.outputTokens,
+                          totalTokens: result.usage.totalTokens,
+                      }
+                    : null,
+            }),
+        );
+    } catch (error: any) {
+        if (isMissingAiEnvError(error)) {
+            return NextResponse.json(
+                ResponseUtil.error({
+                    code: ErrorCodes.ERROR,
+                    message: 'AI service is not configured. Set DORY_AI_PROVIDER and related environment variables.',
+                }),
+                { status: 503 },
+            );
+        }
+
+        console.error('[automation/ai/ask] failed', error);
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.ERROR,
+                message: error?.message ?? 'AI request failed',
+            }),
+            { status: 500 },
+        );
+    }
+});

--- a/apps/web/app/api/automation/connections/route.ts
+++ b/apps/web/app/api/automation/connections/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { ResponseUtil } from '@/lib/result';
+import { withAutomationHandler } from '../with-automation-handler';
+import { ensureDemoConnection } from '@/lib/demo/ensure-demo-connection';
+
+/**
+ * GET /api/automation/connections
+ *
+ * List all database connections for the organization.
+ * Returns metadata only (no passwords or secrets).
+ */
+export const GET = withAutomationHandler(async ({ db, userId, organizationId }) => {
+    let data = await db.connections.list(organizationId);
+
+    if (data.length === 0) {
+        try {
+            await ensureDemoConnection(db, userId, organizationId);
+            data = await db.connections.list(organizationId);
+        } catch (err) {
+            console.warn('[automation/connections] failed to create demo connection:', err);
+        }
+    }
+
+    return NextResponse.json(ResponseUtil.success(data));
+});

--- a/apps/web/app/api/automation/query/execute/route.ts
+++ b/apps/web/app/api/automation/query/execute/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from 'next/server';
+import { ErrorCodes } from '@/lib/errors';
+import { ResponseUtil } from '@/lib/result';
+import { getOrCreateConnectionPool } from '@/lib/connection/connection-service';
+import { splitMultiSQL } from '@/lib/utils/split-multi-sql';
+import { BaseConnection } from '@/lib/connection/base/base-connection';
+import { withAutomationHandler } from '../../with-automation-handler';
+import { parseSqlOp, MAX_STATEMENTS } from '../../utils';
+
+async function executeStatement(
+    connection: BaseConnection,
+    statement: string,
+    context: { database?: string },
+) {
+    const perfStart = performance.now();
+    try {
+        const result = await connection.queryWithContext(statement, {
+            database: context.database,
+        });
+        const rows = result.rows ?? [];
+        const durationMs = Math.round(performance.now() - perfStart);
+        const isArrayRows = Array.isArray(rows);
+
+        return {
+            ok: true as const,
+            sql: statement,
+            operation: parseSqlOp(statement),
+            columns: result.columns ?? null,
+            rows: isArrayRows ? rows : [],
+            rowCount: result.rowCount ?? (isArrayRows ? rows.length : 0),
+            durationMs,
+        };
+    } catch (err: any) {
+        const durationMs = Math.round(performance.now() - perfStart);
+        return {
+            ok: false as const,
+            sql: statement,
+            operation: parseSqlOp(statement),
+            columns: null,
+            rows: [],
+            rowCount: 0,
+            durationMs,
+            error: {
+                message: String(err?.message || err),
+                code: err?.code ?? null,
+            },
+        };
+    }
+}
+
+/**
+ * POST /api/automation/query/execute
+ *
+ * Execute SQL against a database connection.
+ *
+ * Body:
+ * {
+ *   "connectionId": "xxx",
+ *   "sql": "SELECT * FROM users LIMIT 100",
+ *   "database": "mydb"          // optional
+ *   "stopOnError": true          // optional, default true
+ * }
+ */
+export const POST = withAutomationHandler(async ({ req, organizationId }) => {
+    const body = await req.json();
+    const { connectionId, sql, database, stopOnError = true } = body;
+
+    if (!connectionId) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.INVALID_PARAMS,
+                message: 'Missing required field: connectionId',
+            }),
+            { status: 400 },
+        );
+    }
+
+    if (!sql || typeof sql !== 'string' || !sql.trim()) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.INVALID_PARAMS,
+                message: 'Missing required field: sql',
+            }),
+            { status: 400 },
+        );
+    }
+
+    const poolEntry = await getOrCreateConnectionPool(organizationId, connectionId);
+    if (!poolEntry) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.NOT_FOUND,
+                message: 'Connection not found or could not be established.',
+            }),
+            { status: 404 },
+        );
+    }
+
+    const connection = poolEntry.instance;
+    const statements = splitMultiSQL(sql).filter(s => !!s.trim());
+
+    if (!statements.length) {
+        return NextResponse.json(ResponseUtil.success({ results: [], durationMs: 0 }));
+    }
+
+    if (statements.length > MAX_STATEMENTS) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.VALIDATION_ERROR,
+                message: `Too many statements (${statements.length}). Maximum is ${MAX_STATEMENTS}.`,
+            }),
+            { status: 400 },
+        );
+    }
+
+    const perfStart = performance.now();
+    const results: Array<Awaited<ReturnType<typeof executeStatement>>> = [];
+
+    for (const statement of statements) {
+        const result = await executeStatement(connection, statement, { database });
+        results.push(result);
+        if (!result.ok && stopOnError) break;
+    }
+
+    const totalDurationMs = Math.round(performance.now() - perfStart);
+
+    return NextResponse.json(
+        ResponseUtil.success({
+            results,
+            summary: {
+                totalStatements: results.length,
+                successful: results.filter(r => r.ok).length,
+                failed: results.filter(r => !r.ok).length,
+                durationMs: totalDurationMs,
+            },
+        }),
+    );
+});

--- a/apps/web/app/api/automation/schema/route.ts
+++ b/apps/web/app/api/automation/schema/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ErrorCodes } from '@/lib/errors';
+import { ResponseUtil } from '@/lib/result';
+import { ensureConnectionPoolForUser } from '@/app/api/connection/utils';
+import { hasMetadataCapability } from '@/lib/connection/base/types';
+import { withAutomationHandler } from '../with-automation-handler';
+
+/**
+ * GET /api/automation/schema?connectionId=xxx&database=mydb
+ *
+ * Get database schema (tables, columns, views) for a given connection.
+ */
+export const GET = withAutomationHandler(async ({ req, userId, organizationId }) => {
+    const connectionId = req.nextUrl.searchParams.get('connectionId');
+    if (!connectionId) {
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.INVALID_PARAMS,
+                message: 'Missing required query parameter: connectionId',
+            }),
+            { status: 400 },
+        );
+    }
+
+    const database = req.nextUrl.searchParams.get('database');
+
+    try {
+        const { entry, config } = await ensureConnectionPoolForUser(userId, organizationId, connectionId, null);
+        const metadata = entry.instance.capabilities.metadata;
+
+        const targetDatabase = database ?? (typeof config.database === 'string' ? config.database : 'default');
+        if (!hasMetadataCapability(metadata, 'getSchema')) {
+            return NextResponse.json(
+                ResponseUtil.error({
+                    code: ErrorCodes.ERROR,
+                    message: 'This connection does not support schema introspection.',
+                }),
+                { status: 400 },
+            );
+        }
+
+        const schema = await metadata.getSchema(targetDatabase);
+        return NextResponse.json(ResponseUtil.success({ schema }));
+    } catch (error: any) {
+        console.error('[automation/schema] failed', error);
+        return NextResponse.json(
+            ResponseUtil.error({
+                code: ErrorCodes.ERROR,
+                message: error?.message ?? 'Failed to retrieve schema',
+            }),
+            { status: 500 },
+        );
+    }
+});

--- a/apps/web/app/api/automation/utils.ts
+++ b/apps/web/app/api/automation/utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure utility functions for the Automation API.
+ * Kept free of framework imports (@/, Next.js) so they can be tested directly.
+ */
+
+/**
+ * Resolves organization ID from headers (in priority order):
+ * 1. x-organization-id header
+ * 2. x-org-id header (shorthand)
+ */
+export function resolveOrganizationIdFromHeaders(headers: Headers): string | null {
+    return headers.get('x-organization-id') ?? headers.get('x-org-id') ?? null;
+}
+
+/**
+ * Classify a SQL statement by its leading keyword.
+ */
+export function parseSqlOp(s: string): string {
+    const first = s.trim().split(/\s+/)[0]?.toUpperCase() || 'SQL';
+    if (['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'REPLACE'].includes(first)) return first;
+    if (['CREATE', 'ALTER', 'DROP', 'TRUNCATE', 'RENAME'].includes(first)) return 'DDL';
+    if (['BEGIN', 'START', 'COMMIT', 'ROLLBACK', 'SAVEPOINT', 'RELEASE'].includes(first)) return 'TXN';
+    return first;
+}
+
+/**
+ * Check whether a SQL statement is read-only (safe for AI execution).
+ */
+export function isReadOnlyQuery(sql: string): boolean {
+    return /^(select|show|describe|desc|explain|with)\b/i.test(sql.trim());
+}
+
+/** Maximum SQL statements per automation execute request. */
+export const MAX_STATEMENTS = 100;
+
+/** Maximum rows returned from AI SQL runner. */
+export const AI_ROW_LIMIT = 200;

--- a/apps/web/app/api/automation/with-automation-handler.ts
+++ b/apps/web/app/api/automation/with-automation-handler.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSessionFromRequest } from '@/lib/auth/session';
+import { getDBService } from '@/lib/database';
+import { ErrorCodes } from '@/lib/errors';
+import { ResponseUtil } from '@/lib/result';
+import { resolveOrganizationAccess } from '@/lib/server/authz';
+
+type AutomationHandlerContext = {
+    req: NextRequest;
+    db: Awaited<ReturnType<typeof getDBService>>;
+    userId: string;
+    organizationId: string;
+};
+
+type AutomationHandlerFn = (ctx: AutomationHandlerContext) => Promise<Response>;
+
+import { resolveOrganizationIdFromHeaders } from './utils';
+
+/**
+ * Handler wrapper for Automation API endpoints.
+ *
+ * Supports authentication via:
+ * - Cookie-based session (same as web UI)
+ * - Bearer token in Authorization header (for CLI / external usage)
+ *
+ * Organization context is resolved from:
+ * - x-organization-id header (required for automation)
+ */
+export function withAutomationHandler(handler: AutomationHandlerFn) {
+    return async function routeHandler(req: NextRequest): Promise<Response> {
+        try {
+            const session = await getSessionFromRequest(req);
+            const userId = session?.user?.id ?? null;
+
+            if (!userId) {
+                return NextResponse.json(
+                    ResponseUtil.error({
+                        code: ErrorCodes.UNAUTHORIZED,
+                        message: 'Authentication required. Provide a session cookie or Authorization: Bearer <token> header.',
+                    }),
+                    { status: 401 },
+                );
+            }
+
+            const organizationId = resolveOrganizationIdFromHeaders(req.headers);
+            if (!organizationId) {
+                return NextResponse.json(
+                    ResponseUtil.error({
+                        code: ErrorCodes.UNAUTHORIZED,
+                        message: 'Missing organization context. Provide x-organization-id header.',
+                    }),
+                    { status: 400 },
+                );
+            }
+
+            const access = await resolveOrganizationAccess(organizationId, userId);
+            if (!access?.isMember) {
+                return NextResponse.json(
+                    ResponseUtil.error({
+                        code: ErrorCodes.FORBIDDEN,
+                        message: 'You do not have access to this organization.',
+                    }),
+                    { status: 403 },
+                );
+            }
+
+            const db = await getDBService();
+
+            return await handler({ req, db, userId, organizationId });
+        } catch (err: any) {
+            console.error('[automation] handler error', err);
+            return NextResponse.json(
+                ResponseUtil.error({
+                    code: ErrorCodes.DATABASE_ERROR,
+                    message: err?.message ?? 'Internal server error',
+                }),
+                { status: 500 },
+            );
+        }
+    };
+}

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -60,52 +60,57 @@ function createAuth() {
             ...(betterAuthApiUrl ? { apiUrl: betterAuthApiUrl } : {}),
             ...(betterAuthKvUrl ? { kvUrl: betterAuthKvUrl } : {}),
         };
+        const infraEnabled = Boolean(betterAuthApiKey);
         const authPlugins = [
             jwt(),
-            dash({
-                ...betterAuthInfraOptions,
-                activityTracking: {
-                    enabled: true,
-                    updateInterval: 300000,
-                },
-            }),
-            sentinel({
-                ...betterAuthInfraOptions,
-                security: {
-                    credentialStuffing: {
-                        enabled: true,
-                        thresholds: {
-                            challenge: 3,
-                            block: 5,
-                        },
-                        windowSeconds: 3600,
-                        cooldownSeconds: 900,
-                    },
-                    impossibleTravel: {
-                        enabled: true,
-                        action: 'log',
-                    },
-                    botBlocking: {
-                        action: 'challenge',
-                    },
-                    suspiciousIpBlocking: {
-                        action: 'challenge',
-                    },
-                    velocity: {
-                        enabled: true,
-                        thresholds: {
-                            challenge: 10,
-                            block: 20,
-                        },
-                        maxSignupsPerVisitor: 5,
-                        maxPasswordResetsPerIp: 10,
-                        maxSignInsPerIp: 50,
-                        windowSeconds: 3600,
-                        action: 'challenge',
-                    },
-                    challengeDifficulty: 18,
-                },
-            }),
+            ...(infraEnabled
+                ? [
+                      dash({
+                          ...betterAuthInfraOptions,
+                          activityTracking: {
+                              enabled: true,
+                              updateInterval: 300000,
+                          },
+                      }),
+                      sentinel({
+                          ...betterAuthInfraOptions,
+                          security: {
+                              credentialStuffing: {
+                                  enabled: true,
+                                  thresholds: {
+                                      challenge: 3,
+                                      block: 5,
+                                  },
+                                  windowSeconds: 3600,
+                                  cooldownSeconds: 900,
+                              },
+                              impossibleTravel: {
+                                  enabled: true,
+                                  action: 'log',
+                              },
+                              botBlocking: {
+                                  action: 'challenge',
+                              },
+                              suspiciousIpBlocking: {
+                                  action: 'challenge',
+                              },
+                              velocity: {
+                                  enabled: true,
+                                  thresholds: {
+                                      challenge: 10,
+                                      block: 20,
+                                  },
+                                  maxSignupsPerVisitor: 5,
+                                  maxPasswordResetsPerIp: 10,
+                                  maxSignInsPerIp: 50,
+                                  windowSeconds: 3600,
+                                  action: 'challenge',
+                              },
+                              challengeDifficulty: 18,
+                          },
+                      }),
+                  ]
+                : []),
         ];
 
         async function findInitialOrganizationId(userId: string): Promise<string | null> {

--- a/apps/web/scripts/tests/automation-api.test.ts
+++ b/apps/web/scripts/tests/automation-api.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    resolveOrganizationIdFromHeaders,
+    parseSqlOp,
+    isReadOnlyQuery,
+    MAX_STATEMENTS,
+    AI_ROW_LIMIT,
+} from '../../app/api/automation/utils';
+
+// ---------------------------------------------------------------------------
+// resolveOrganizationIdFromHeaders
+// ---------------------------------------------------------------------------
+
+test('resolveOrganizationIdFromHeaders returns x-organization-id when present', () => {
+    const headers = new Headers({ 'x-organization-id': 'org_123' });
+    assert.equal(resolveOrganizationIdFromHeaders(headers), 'org_123');
+});
+
+test('resolveOrganizationIdFromHeaders falls back to x-org-id', () => {
+    const headers = new Headers({ 'x-org-id': 'org_456' });
+    assert.equal(resolveOrganizationIdFromHeaders(headers), 'org_456');
+});
+
+test('resolveOrganizationIdFromHeaders prefers x-organization-id over x-org-id', () => {
+    const headers = new Headers({
+        'x-organization-id': 'org_primary',
+        'x-org-id': 'org_fallback',
+    });
+    assert.equal(resolveOrganizationIdFromHeaders(headers), 'org_primary');
+});
+
+test('resolveOrganizationIdFromHeaders returns null when no org header present', () => {
+    const headers = new Headers({ 'content-type': 'application/json' });
+    assert.equal(resolveOrganizationIdFromHeaders(headers), null);
+});
+
+test('resolveOrganizationIdFromHeaders returns null for empty headers', () => {
+    const headers = new Headers();
+    assert.equal(resolveOrganizationIdFromHeaders(headers), null);
+});
+
+// ---------------------------------------------------------------------------
+// parseSqlOp
+// ---------------------------------------------------------------------------
+
+test('parseSqlOp identifies SELECT statements', () => {
+    assert.equal(parseSqlOp('SELECT * FROM users'), 'SELECT');
+    assert.equal(parseSqlOp('  select count(*) from orders  '), 'SELECT');
+});
+
+test('parseSqlOp identifies DML statements', () => {
+    assert.equal(parseSqlOp('INSERT INTO users VALUES (1)'), 'INSERT');
+    assert.equal(parseSqlOp('UPDATE users SET name = "a"'), 'UPDATE');
+    assert.equal(parseSqlOp('DELETE FROM users WHERE id = 1'), 'DELETE');
+    assert.equal(parseSqlOp('REPLACE INTO users VALUES (1)'), 'REPLACE');
+});
+
+test('parseSqlOp identifies DDL statements', () => {
+    assert.equal(parseSqlOp('CREATE TABLE foo (id INT)'), 'DDL');
+    assert.equal(parseSqlOp('ALTER TABLE foo ADD col INT'), 'DDL');
+    assert.equal(parseSqlOp('DROP TABLE foo'), 'DDL');
+    assert.equal(parseSqlOp('TRUNCATE TABLE foo'), 'DDL');
+    assert.equal(parseSqlOp('RENAME TABLE foo TO bar'), 'DDL');
+});
+
+test('parseSqlOp identifies transaction statements', () => {
+    assert.equal(parseSqlOp('BEGIN'), 'TXN');
+    assert.equal(parseSqlOp('COMMIT'), 'TXN');
+    assert.equal(parseSqlOp('ROLLBACK'), 'TXN');
+    assert.equal(parseSqlOp('SAVEPOINT sp1'), 'TXN');
+    assert.equal(parseSqlOp('RELEASE sp1'), 'TXN');
+});
+
+test('parseSqlOp returns first keyword for unknown statements', () => {
+    assert.equal(parseSqlOp('SHOW TABLES'), 'SHOW');
+    assert.equal(parseSqlOp('DESCRIBE users'), 'DESCRIBE');
+    assert.equal(parseSqlOp('EXPLAIN SELECT 1'), 'EXPLAIN');
+});
+
+test('parseSqlOp returns SQL for empty input', () => {
+    assert.equal(parseSqlOp(''), 'SQL');
+    assert.equal(parseSqlOp('   '), 'SQL');
+});
+
+// ---------------------------------------------------------------------------
+// isReadOnlyQuery
+// ---------------------------------------------------------------------------
+
+test('isReadOnlyQuery allows SELECT queries', () => {
+    assert.equal(isReadOnlyQuery('SELECT * FROM users'), true);
+    assert.equal(isReadOnlyQuery('  select 1  '), true);
+});
+
+test('isReadOnlyQuery allows SHOW, DESCRIBE, EXPLAIN', () => {
+    assert.equal(isReadOnlyQuery('SHOW TABLES'), true);
+    assert.equal(isReadOnlyQuery('DESCRIBE users'), true);
+    assert.equal(isReadOnlyQuery('DESC users'), true);
+    assert.equal(isReadOnlyQuery('EXPLAIN SELECT 1'), true);
+});
+
+test('isReadOnlyQuery allows WITH (CTE) queries', () => {
+    assert.equal(isReadOnlyQuery('WITH cte AS (SELECT 1) SELECT * FROM cte'), true);
+});
+
+test('isReadOnlyQuery rejects write operations', () => {
+    assert.equal(isReadOnlyQuery('INSERT INTO users VALUES (1)'), false);
+    assert.equal(isReadOnlyQuery('UPDATE users SET name = "a"'), false);
+    assert.equal(isReadOnlyQuery('DELETE FROM users WHERE id = 1'), false);
+    assert.equal(isReadOnlyQuery('DROP TABLE users'), false);
+    assert.equal(isReadOnlyQuery('CREATE TABLE foo (id INT)'), false);
+    assert.equal(isReadOnlyQuery('TRUNCATE TABLE foo'), false);
+});
+
+test('isReadOnlyQuery is case-insensitive', () => {
+    assert.equal(isReadOnlyQuery('Select * from users'), true);
+    assert.equal(isReadOnlyQuery('SHOW databases'), true);
+    assert.equal(isReadOnlyQuery('insert into users values (1)'), false);
+});
+
+// ---------------------------------------------------------------------------
+// constants
+// ---------------------------------------------------------------------------
+
+test('MAX_STATEMENTS is 100', () => {
+    assert.equal(MAX_STATEMENTS, 100);
+});
+
+test('AI_ROW_LIMIT is 200', () => {
+    assert.equal(AI_ROW_LIMIT, 200);
+});

--- a/tests/e2e/automation-api.spec.ts
+++ b/tests/e2e/automation-api.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the Automation API (/api/automation/*).
+ *
+ * These tests run against a live Dory instance.
+ * They use direct HTTP requests (not browser context) to bypass
+ * any client-side rendering issues with the auth setup.
+ */
+
+// Skip the browser-based auth setup — we authenticate via API directly.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+let sessionCookie: string;
+let organizationId: string;
+let connectionId: string | null = null;
+
+test.describe.serial('Automation API', () => {
+    test('authenticate demo user via API', async ({ request }) => {
+        const demoRes = await request.post('/api/auth/demo', {
+            headers: { 'Content-Type': 'application/json' },
+        });
+        expect(demoRes.ok()).toBeTruthy();
+
+        const setCookie = demoRes.headers()['set-cookie'] ?? '';
+        const match = setCookie.match(/better-auth\.session_token=([^;]+)/);
+        expect(match, 'should receive session cookie').toBeTruthy();
+        sessionCookie = `better-auth.session_token=${match![1]}`;
+
+        // Resolve organization ID from session
+        const sessionRes = await request.get('/api/auth/get-session', {
+            headers: { Cookie: sessionCookie },
+        });
+        expect(sessionRes.ok()).toBeTruthy();
+        const session = await sessionRes.json();
+        organizationId = session?.session?.activeOrganizationId;
+        expect(organizationId, 'should have an active organization').toBeTruthy();
+    });
+
+    test('returns 400 without x-organization-id header', async ({ request }) => {
+        const res = await request.get('/api/automation/connections', {
+            headers: { Cookie: sessionCookie },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        expect(body?.message).toContain('organization');
+    });
+
+    test('returns 403 for wrong organization', async ({ request }) => {
+        const res = await request.get('/api/automation/connections', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': 'nonexistent-org-id',
+            },
+        });
+        expect(res.status()).toBe(403);
+    });
+
+    test('GET /api/automation/connections lists connections', async ({ request }) => {
+        const res = await request.get('/api/automation/connections', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+            },
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body?.code).toBe(0);
+
+        const connections = body?.data;
+        expect(Array.isArray(connections)).toBe(true);
+
+        if (connections.length > 0) {
+            const conn = connections[0];
+            expect(conn?.connection?.id).toBeTruthy();
+            connectionId = conn.connection.id;
+        }
+    });
+
+    test('GET /api/automation/schema returns 400 without connectionId', async ({ request }) => {
+        const res = await request.get('/api/automation/schema', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+            },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        expect(body?.message).toContain('connectionId');
+    });
+
+    test('POST /api/automation/query/execute returns 400 without connectionId', async ({ request }) => {
+        const res = await request.post('/api/automation/query/execute', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+                'Content-Type': 'application/json',
+            },
+            data: { sql: 'SELECT 1' },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        expect(body?.message).toContain('connectionId');
+    });
+
+    test('POST /api/automation/query/execute returns 400 without sql', async ({ request }) => {
+        test.skip(!connectionId, 'no connection available');
+
+        const res = await request.post('/api/automation/query/execute', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+                'Content-Type': 'application/json',
+            },
+            data: { connectionId },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        expect(body?.message).toContain('sql');
+    });
+
+    test('POST /api/automation/query/execute runs SQL', async ({ request }) => {
+        test.skip(!connectionId, 'no connection available');
+
+        const res = await request.post('/api/automation/query/execute', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+                'Content-Type': 'application/json',
+            },
+            data: { connectionId, sql: 'SELECT 1 AS value' },
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body?.code).toBe(0);
+        expect(body?.data?.results?.length).toBe(1);
+        expect(body?.data?.results?.[0]?.ok).toBe(true);
+        expect(body?.data?.results?.[0]?.rows?.length).toBeGreaterThan(0);
+        expect(body?.data?.summary?.successful).toBe(1);
+        expect(body?.data?.summary?.failed).toBe(0);
+    });
+
+    test('POST /api/automation/query/execute handles multi-statement SQL', async ({ request }) => {
+        test.skip(!connectionId, 'no connection available');
+
+        const res = await request.post('/api/automation/query/execute', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+                'Content-Type': 'application/json',
+            },
+            data: { connectionId, sql: 'SELECT 1 AS a; SELECT 2 AS b' },
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body?.data?.results?.length).toBe(2);
+        expect(body?.data?.summary?.totalStatements).toBe(2);
+        expect(body?.data?.summary?.successful).toBe(2);
+    });
+
+    test('POST /api/automation/query/execute stopOnError stops at first failure', async ({ request }) => {
+        test.skip(!connectionId, 'no connection available');
+
+        const res = await request.post('/api/automation/query/execute', {
+            headers: {
+                Cookie: sessionCookie,
+                'x-organization-id': organizationId,
+                'Content-Type': 'application/json',
+            },
+            data: {
+                connectionId,
+                sql: 'SELECT * FROM nonexistent_table_xyz; SELECT 1 AS value',
+                stopOnError: true,
+            },
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body?.data?.results?.length).toBe(1);
+        expect(body?.data?.results?.[0]?.ok).toBe(false);
+        expect(body?.data?.summary?.failed).toBe(1);
+    });
+});

--- a/tests/e2e/playwright-automation.config.ts
+++ b/tests/e2e/playwright-automation.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3100';
+
+export default defineConfig({
+    testDir: '.',
+    testMatch: 'automation-api.spec.ts',
+    timeout: 30_000,
+    use: { baseURL },
+    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});


### PR DESCRIPTION
## Summary

Closes #116

- Add `/api/automation/*` endpoints for programmatic access to Dory without UI:
  - `GET /api/automation/connections` — list database connections
  - `GET /api/automation/schema?connectionId=xxx` — get database schema
  - `POST /api/automation/query/execute` — execute SQL queries
  - `POST /api/automation/ai/ask` — natural language data queries (AI generates & runs SQL)
- Auth supports both cookie sessions and `Authorization: Bearer <token>` with `x-organization-id` header
- Skip dash/sentinel auth plugins when `BETTER_AUTH_API_KEY` is not set (fixes local/test environments)

## Usage

```bash
# List connections
curl -H "Authorization: Bearer $TOKEN" \
     -H "x-organization-id: $ORG_ID" \
     /api/automation/connections

# Execute SQL
curl -X POST -H "Authorization: Bearer $TOKEN" \
     -H "x-organization-id: $ORG_ID" \
     -H "Content-Type: application/json" \
     -d '{"connectionId":"xxx","sql":"SELECT * FROM users LIMIT 10"}' \
     /api/automation/query/execute

# AI Ask
curl -X POST -H "Authorization: Bearer $TOKEN" \
     -H "x-organization-id: $ORG_ID" \
     -H "Content-Type: application/json" \
     -d '{"connectionId":"xxx","question":"Top 10 users by order amount"}' \
     /api/automation/ai/ask
```

## Test plan

- [x] Unit tests: 18 tests passing (`npx tsx apps/web/scripts/tests/automation-api.test.ts`)
- [x] E2E tests: 10 tests passing (`npx playwright test --config tests/e2e/playwright-automation.config.ts`)
- [x] Manual curl testing against all 4 endpoints
- [ ] Verify in production-like environment with real database connections