### PR TITLE
feat: add pagination to Data Preview tab

### DIFF
--- a/apps/web/app/(app)/[organization]/components/table-browser/components/data-preview/DataPreviewPaginationBar.tsx
+++ b/apps/web/app/(app)/[organization]/components/table-browser/components/data-preview/DataPreviewPaginationBar.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/registry/new-york-v4/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/registry/new-york-v4/ui/select';
+
+const PAGE_SIZE_OPTIONS = [50, 100, 200, 500, 1000];
+
+type DataPreviewPaginationBarProps = {
+    pageIndex: number;
+    pageSize: number;
+    totalRowEstimate: number | null;
+    currentPageRowCount: number;
+    loading: boolean;
+    onPageChange: (pageIndex: number) => void;
+    onPageSizeChange: (pageSize: number) => void;
+};
+
+export function DataPreviewPaginationBar({
+    pageIndex,
+    pageSize,
+    totalRowEstimate,
+    currentPageRowCount,
+    loading,
+    onPageChange,
+    onPageSizeChange,
+}: DataPreviewPaginationBarProps) {
+    const t = useTranslations('TableBrowser');
+
+    const hasPrevious = pageIndex > 0;
+    const hasNext = currentPageRowCount >= pageSize;
+
+    const totalPages = totalRowEstimate != null && totalRowEstimate > 0
+        ? Math.ceil(totalRowEstimate / pageSize)
+        : null;
+
+    const start = pageIndex * pageSize + 1;
+    const end = pageIndex * pageSize + currentPageRowCount;
+
+    const pageLabel = totalPages != null
+        ? t('Pagination.PageOf', { current: pageIndex + 1, total: totalPages })
+        : t('Pagination.PageUnknown', { current: pageIndex + 1 });
+
+    const rowsLabel = totalRowEstimate != null
+        ? t('Pagination.ShowingRange', { start: start.toLocaleString(), end: end.toLocaleString(), total: totalRowEstimate.toLocaleString() })
+        : t('Pagination.ShowingCount', { count: currentPageRowCount.toLocaleString() });
+
+    return (
+        <div className="flex-none flex items-center justify-between border-t bg-card px-3 py-1 text-xs text-muted-foreground">
+            <div className="flex items-center gap-3">
+                <div className="flex items-center gap-1">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        disabled={!hasPrevious || loading}
+                        onClick={() => onPageChange(pageIndex - 1)}
+                        aria-label={t('Pagination.Previous')}
+                    >
+                        <ChevronLeft className="h-3.5 w-3.5" />
+                    </Button>
+                    <span className="px-1 tabular-nums">{pageLabel}</span>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        disabled={!hasNext || loading}
+                        onClick={() => onPageChange(pageIndex + 1)}
+                        aria-label={t('Pagination.Next')}
+                    >
+                        <ChevronRight className="h-3.5 w-3.5" />
+                    </Button>
+                </div>
+
+                <div className="flex items-center gap-1.5">
+                    <span>{t('Pagination.RowsPerPage')}</span>
+                    <Select
+                        value={String(pageSize)}
+                        onValueChange={(value) => onPageSizeChange(Number(value))}
+                    >
+                        <SelectTrigger className="h-6 w-[70px] text-xs">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {PAGE_SIZE_OPTIONS.map((size) => (
+                                <SelectItem key={size} value={String(size)} className="text-xs">
+                                    {size}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+
+            {currentPageRowCount > 0 && (
+                <span className="tabular-nums">{rowsLabel}</span>
+            )}
+        </div>
+    );
+}

--- a/apps/web/app/(app)/[organization]/components/table-browser/components/data-preview/index.tsx
+++ b/apps/web/app/(app)/[organization]/components/table-browser/components/data-preview/index.tsx
@@ -17,6 +17,8 @@ import { currentSessionMetaAtom } from '../../../../[connectionId]/sql-console/c
 import VTable from '../../../../[connectionId]/sql-console/components/result-table/vtable';
 import { InspectorPanel } from '../../../../[connectionId]/sql-console/components/result-table/vtable/InspectorPanel';
 import { DEFAULT_TABLE_PREVIEW_LIMIT } from '@/shared/data/app.data';
+import { useTablePropertiesQuery } from '../table-queries';
+import { DataPreviewPaginationBar } from './DataPreviewPaginationBar';
 
 type PreviewColumn = {
     name: string;
@@ -93,6 +95,11 @@ function DataPreview({
     const [inspectorPayload, setInspectorPayload] = useState<any>(null);
     const [rowViewMode, setRowViewMode] = useState<'table' | 'json'>('table');
     const [inspectorWidth, setInspectorWidth] = useState(360);
+    const [pageIndex, setPageIndex] = useState(0);
+    const [pageSize, setPageSize] = useState(DEFAULT_TABLE_PREVIEW_LIMIT);
+
+    const { data: tableProperties } = useTablePropertiesQuery({ connectionId, databaseName, tableName });
+    const totalRowEstimate = tableProperties?.totalRows ?? null;
 
     useEffect(() => {
         setRows([]);
@@ -106,6 +113,7 @@ function DataPreview({
         setInspectorPayload(null);
         setRowViewMode('table');
         setError(null);
+        setPageIndex(0);
     }, [connectionId, databaseName, tableName, setSessionMeta]);
 
     const runPreview = useCallback(
@@ -120,7 +128,8 @@ function DataPreview({
                     connectionId,
                     databaseName,
                     tableName,
-                    limit: DEFAULT_TABLE_PREVIEW_LIMIT,
+                    limit: pageSize,
+                    offset: pageIndex * pageSize,
                     source,
                     signal,
                 });
@@ -151,7 +160,7 @@ function DataPreview({
                 }
             }
         },
-        [connectionId, databaseName, source, storageKey, tableName, setSessionMeta, t],
+        [connectionId, databaseName, source, storageKey, tableName, setSessionMeta, t, pageSize, pageIndex],
     );
 
     useEffect(() => {
@@ -211,6 +220,15 @@ function DataPreview({
         [filteredResults.length],
     );
 
+    const handlePageChange = useCallback((newPageIndex: number) => {
+        setPageIndex(newPageIndex);
+    }, []);
+
+    const handlePageSizeChange = useCallback((newPageSize: number) => {
+        setPageSize(newPageSize);
+        setPageIndex(0);
+    }, []);
+
     const handleRefresh = useCallback(() => {
         if (loading) return;
         void runPreview();
@@ -257,8 +275,8 @@ function DataPreview({
     }
 
     return (
-        <div className="h-full min-h-0">
-            <div className="flex items-center justify-between w-full gap-3">
+        <div className="h-full min-h-0 flex flex-col">
+            <div className="flex items-center justify-between w-full gap-3 flex-none">
                 <VTableSearchBar
                     query={query}
                     className="w-96 pl-0"
@@ -273,14 +291,26 @@ function DataPreview({
                 </Button>
             </div>
 
-            <VTable
-                results={filteredResults}
-                storageKey={storageKey}
-                onStatsChange={onStatsChange}
-                showSearchBar={true}
-                setInspectorOpen={setInspectorOpen}
-                setInspectorMode={setInspectorMode}
-                setInspectorPayload={setInspectorPayload}
+            <div className="flex-1 min-h-0">
+                <VTable
+                    results={filteredResults}
+                    storageKey={storageKey}
+                    onStatsChange={onStatsChange}
+                    showSearchBar={true}
+                    setInspectorOpen={setInspectorOpen}
+                    setInspectorMode={setInspectorMode}
+                    setInspectorPayload={setInspectorPayload}
+                />
+            </div>
+
+            <DataPreviewPaginationBar
+                pageIndex={pageIndex}
+                pageSize={pageSize}
+                totalRowEstimate={totalRowEstimate}
+                currentPageRowCount={rows.length}
+                loading={loading}
+                onPageChange={handlePageChange}
+                onPageSizeChange={handlePageSizeChange}
             />
 
             <InspectorPanel

--- a/apps/web/app/(app)/[organization]/components/table-browser/components/data-preview/index.tsx
+++ b/apps/web/app/(app)/[organization]/components/table-browser/components/data-preview/index.tsx
@@ -282,8 +282,8 @@ function DataPreview({
                     className="w-96 pl-0"
                     onQueryChange={setQuery}
                     onClearQuery={() => setQuery('')}
-                    filteredCount={stats.filteredCount}
-                    totalCount={stats.totalCount}
+                    filteredCount={query.trim() ? stats.filteredCount : undefined}
+                    totalCount={query.trim() ? stats.totalCount : undefined}
                 />
                 <Button variant="ghost" size="sm" className="gap-2" onClick={handleRefresh} disabled={loading}>
                     <RotateCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />

--- a/apps/web/app/(app)/[organization]/components/table-browser/lib/fetch-table-preview.ts
+++ b/apps/web/app/(app)/[organization]/components/table-browser/lib/fetch-table-preview.ts
@@ -6,6 +6,7 @@ type FetchTablePreviewParams = {
     databaseName: string;
     tableName: string;
     limit?: number;
+    offset?: number;
     sessionId?: string;
     tabId?: string;
     source?: string;
@@ -17,6 +18,7 @@ export async function fetchTablePreview({
     databaseName,
     tableName,
     limit,
+    offset,
     sessionId,
     tabId,
     source,
@@ -32,6 +34,7 @@ export async function fetchTablePreview({
         },
         body: JSON.stringify({
             limit,
+            offset,
             sessionId,
             tabId,
             source,

--- a/apps/web/app/api/connection/[id]/databases/[database]/tables/[table]/preview/route.ts
+++ b/apps/web/app/api/connection/[id]/databases/[database]/tables/[table]/preview/route.ts
@@ -13,6 +13,7 @@ const buildPreviewSchema = (t: (key: string, values?: Record<string, unknown>) =
         database: z.string().min(1, t('Api.Connection.Validation.DatabaseRequired')),
         table: z.string().min(1, t('Api.Connection.Validation.TableRequired')),
         limit: z.number().int().positive().max(10000).optional().default(DEFAULT_TABLE_PREVIEW_LIMIT),
+        offset: z.number().int().min(0).optional().default(0),
         sessionId: z.string().min(1).optional(),
         tabId: z.string().min(1).optional(),
         source: z.string().min(1).optional(),
@@ -52,6 +53,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
             database: safeDecode(params?.database),
             table: safeDecode(params?.table),
             limit: typeof body?.limit === 'number' ? body.limit : undefined,
+            offset: typeof body?.offset === 'number' ? body.offset : undefined,
             sessionId: typeof body?.sessionId === 'string' ? body.sessionId : undefined,
             tabId: typeof body?.tabId === 'string' ? body.tabId : undefined,
             source: typeof body?.source === 'string' ? body.source : undefined,
@@ -67,7 +69,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
             );
         }
 
-        const { database, table, limit, sessionId, tabId, source } = parsed.data;
+        const { database, table, limit, offset, sessionId, tabId, source } = parsed.data;
 
         try {
             const { entry } = await ensureConnectionPoolForUser(userId, organizationId, datasourceId, null);
@@ -77,6 +79,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
                 database,
                 table,
                 limit,
+                offset,
                 sessionId,
                 tabId,
                 userId,

--- a/apps/web/lib/connection/base/types.ts
+++ b/apps/web/lib/connection/base/types.ts
@@ -176,6 +176,7 @@ export type Pagination = {
 
 export type TablePreviewOptions = {
     limit?: number;
+    offset?: number;
 };
 
 export type QueryInsightsImpl = {

--- a/apps/web/lib/connection/drivers/clickhouse/capabilities/table-info.ts
+++ b/apps/web/lib/connection/drivers/clickhouse/capabilities/table-info.ts
@@ -189,17 +189,19 @@ async function getTablePreview(
     datasource: ClickhouseDatasource,
     database: string,
     table: string,
-    options?: { limit?: number },
+    options?: { limit?: number; offset?: number },
 ) {
     const limit = normalizePreviewLimit(options?.limit);
+    const offset = options?.offset ?? 0;
     const result = await datasource.queryWithContext<Record<string, unknown>>(
-        'SELECT * FROM {db:Identifier}.{tbl:Identifier} LIMIT {limit:UInt64}',
+        'SELECT * FROM {db:Identifier}.{tbl:Identifier} LIMIT {limit:UInt64} OFFSET {offset:UInt64}',
         {
             database,
             params: {
                 db: database,
                 tbl: table,
                 limit,
+                offset,
             },
         },
     );

--- a/apps/web/lib/connection/drivers/mysql/capabilities/table-info.ts
+++ b/apps/web/lib/connection/drivers/mysql/capabilities/table-info.ts
@@ -213,12 +213,13 @@ async function getTableStats(datasource: MySqlDatasource, database: string, tabl
     };
 }
 
-async function getTablePreview(datasource: MySqlDatasource, database: string, table: string, options?: { limit?: number }) {
+async function getTablePreview(datasource: MySqlDatasource, database: string, table: string, options?: { limit?: number; offset?: number }) {
     const target = resolveTableInput(database, table);
     const limit = normalizePreviewLimit(options?.limit);
-    const result = await datasource.queryWithContext<Record<string, unknown>>(`SELECT * FROM ${quoteMysqlQualifiedTable(target.database, target.table)} LIMIT ?`, {
+    const offset = options?.offset ?? 0;
+    const result = await datasource.queryWithContext<Record<string, unknown>>(`SELECT * FROM ${quoteMysqlQualifiedTable(target.database, target.table)} LIMIT ? OFFSET ?`, {
         database: target.database,
-        params: [limit],
+        params: [limit, offset],
     });
 
     return {

--- a/apps/web/lib/connection/drivers/postgres/capabilities/table-info.ts
+++ b/apps/web/lib/connection/drivers/postgres/capabilities/table-info.ts
@@ -328,15 +328,16 @@ async function getTableStats(datasource: PostgresDatasource, database: string, t
     };
 }
 
-async function getTablePreview(datasource: PostgresDatasource, database: string, table: string, options?: { limit?: number }) {
+async function getTablePreview(datasource: PostgresDatasource, database: string, table: string, options?: { limit?: number; offset?: number }) {
     const parsed = parseTableName(table);
     const schemaName = parsed.schema?.trim() || 'public';
     const tableName = parsed.name.trim();
     const limit = normalizePreviewLimit(options?.limit);
+    const offset = options?.offset ?? 0;
     const qualifiedName = `${quoteIdentifier(schemaName)}.${quoteIdentifier(tableName)}`;
-    const result = await datasource.queryWithContext<Record<string, unknown>>(`SELECT * FROM ${qualifiedName} LIMIT $1`, {
+    const result = await datasource.queryWithContext<Record<string, unknown>>(`SELECT * FROM ${qualifiedName} LIMIT $1 OFFSET $2`, {
         database,
-        params: [limit],
+        params: [limit, offset],
     });
 
     return {

--- a/apps/web/lib/connection/drivers/sqlite/capabilities/table-info.ts
+++ b/apps/web/lib/connection/drivers/sqlite/capabilities/table-info.ts
@@ -14,7 +14,7 @@ export function createSqliteTableInfoCapability(datasource: SqliteDatasource): G
             return null;
         },
         async preview(database, table, options) {
-            return previewSqliteTable(datasource.getDatabase(), database, table, options?.limit ?? 100);
+            return previewSqliteTable(datasource.getDatabase(), database, table, options?.limit ?? 100, options?.offset ?? 0);
         },
         async indexes(database, table) {
             return getSqliteTableIndexes(datasource.getDatabase(), database, table);

--- a/apps/web/lib/connection/drivers/sqlite/sqlite-driver.ts
+++ b/apps/web/lib/connection/drivers/sqlite/sqlite-driver.ts
@@ -219,9 +219,10 @@ export function previewSqliteTable(
     database: string,
     table: string,
     limit: number,
+    offset: number = 0,
 ): QueryResult<Record<string, unknown>> {
-    const sql = `SELECT * FROM ${buildQualifiedName(database, table)} LIMIT ?`;
-    return executeSqliteQuery<Record<string, unknown>>(db, sql, [limit]);
+    const sql = `SELECT * FROM ${buildQualifiedName(database, table)} LIMIT ? OFFSET ?`;
+    return executeSqliteQuery<Record<string, unknown>>(db, sql, [limit, offset]);
 }
 
 export function getSqliteTableIndexes(db: SqliteDatabase, database: string, table: string): TableIndexInfo[] {

--- a/apps/web/lib/connection/table-preview.ts
+++ b/apps/web/lib/connection/table-preview.ts
@@ -9,6 +9,7 @@ type BuildTablePreviewPayloadParams = {
     database: string;
     table: string;
     limit?: number;
+    offset?: number;
     sessionId?: string | null;
     tabId?: string | null;
     userId?: string | null;
@@ -22,6 +23,13 @@ function normalizePreviewLimit(limit?: number): number {
     return Math.floor(limit);
 }
 
+function normalizePreviewOffset(offset?: number): number {
+    if (!Number.isFinite(offset) || !offset || offset < 0) {
+        return 0;
+    }
+    return Math.floor(offset);
+}
+
 function buildPreviewSqlText(database: string, table: string): string {
     return `TABLE PREVIEW ${database}.${table}`;
 }
@@ -32,6 +40,7 @@ export async function buildTablePreviewPayload({
     database,
     table,
     limit,
+    offset,
     sessionId,
     tabId,
     userId,
@@ -43,10 +52,11 @@ export async function buildTablePreviewPayload({
     }
 
     const normalizedLimit = normalizePreviewLimit(limit);
+    const normalizedOffset = normalizePreviewOffset(offset);
     const sqlText = buildPreviewSqlText(database, table);
     const startedAt = new Date();
     const perfStart = performance.now();
-    const result = await tableInfo.preview(database, table, { limit: normalizedLimit });
+    const result = await tableInfo.preview(database, table, { limit: normalizedLimit, offset: normalizedOffset });
     const durationMs = Math.round(performance.now() - perfStart);
     const finishedAt = new Date();
     const rows = Array.isArray(result.rows) ? result.rows : [];
@@ -80,6 +90,7 @@ export async function buildTablePreviewPayload({
                 rowCount: result.rowCount ?? rows.length,
                 limited: result.limited ?? true,
                 limit: result.limit ?? normalizedLimit,
+                offset: normalizedOffset,
                 affectedRows: null,
                 status: 'success' as const,
                 errorMessage: null,

--- a/apps/web/public/locales/en.json
+++ b/apps/web/public/locales/en.json
@@ -397,6 +397,17 @@
         "No data": "No data",
         "Refresh": "Refresh",
         "Failed to load data preview": "Failed to load data preview",
+        "Pagination": {
+            "Previous": "Previous",
+            "Next": "Next",
+            "PageOf": "Page {current} of ~{total}",
+            "PageOfExact": "Page {current} of {total}",
+            "PageUnknown": "Page {current}",
+            "RowsPerPage": "Rows per page",
+            "ShowingRange": "{start}–{end} of ~{total}",
+            "ShowingRangeExact": "{start}–{end} of {total}",
+            "ShowingCount": "{count} rows"
+        },
         "Column name": "Name",
         "Column type": "Type",
         "Nullable": "Nullable",

--- a/apps/web/public/locales/es.json
+++ b/apps/web/public/locales/es.json
@@ -397,6 +397,17 @@
         "No data": "No hay datos",
         "Refresh": "Actualizar",
         "Failed to load data preview": "No se pudo cargar la vista previa de los datos",
+        "Pagination": {
+            "Previous": "Anterior",
+            "Next": "Siguiente",
+            "PageOf": "Página {current} de ~{total}",
+            "PageOfExact": "Página {current} de {total}",
+            "PageUnknown": "Página {current}",
+            "RowsPerPage": "Filas por página",
+            "ShowingRange": "{start}–{end} de ~{total}",
+            "ShowingRangeExact": "{start}–{end} de {total}",
+            "ShowingCount": "{count} filas"
+        },
         "Column name": "Nombre",
         "Column type": "Tipo",
         "Nullable": "Acepta nulos",

--- a/apps/web/public/locales/ja.json
+++ b/apps/web/public/locales/ja.json
@@ -397,6 +397,17 @@
         "No data": "データがありません",
         "Refresh": "更新",
         "Failed to load data preview": "データプレビューの読み込みに失敗しました",
+        "Pagination": {
+            "Previous": "前へ",
+            "Next": "次へ",
+            "PageOf": "ページ {current} / ~{total}",
+            "PageOfExact": "ページ {current} / {total}",
+            "PageUnknown": "ページ {current}",
+            "RowsPerPage": "表示件数",
+            "ShowingRange": "{start}–{end} / ~{total}",
+            "ShowingRangeExact": "{start}–{end} / {total}",
+            "ShowingCount": "{count} 行"
+        },
         "Column name": "名前",
         "Column type": "型",
         "Nullable": "NULL 可",

--- a/apps/web/public/locales/zh.json
+++ b/apps/web/public/locales/zh.json
@@ -399,6 +399,17 @@
         "No data": "没有数据",
         "Refresh": "刷新",
         "Failed to load data preview": "加载数据预览失败",
+        "Pagination": {
+            "Previous": "上一页",
+            "Next": "下一页",
+            "PageOf": "第 {current} 页，共 ~{total} 页",
+            "PageOfExact": "第 {current} 页，共 {total} 页",
+            "PageUnknown": "第 {current} 页",
+            "RowsPerPage": "每页行数",
+            "ShowingRange": "{start}–{end} / ~{total}",
+            "ShowingRangeExact": "{start}–{end} / {total}",
+            "ShowingCount": "{count} 行"
+        },
         "Column name": "名称",
         "Column type": "类型",
         "Nullable": "可为空",


### PR DESCRIPTION
## Summary

- Replace the hard-limited 200-row Data Preview with **DataGrip-style pagination**
- Add `LIMIT/OFFSET` support across all 4 database drivers (PostgreSQL, MySQL, SQLite, ClickHouse)
- New bottom pagination bar with prev/next navigation and configurable page size (50 / 100 / 200 / 500 / 1000)
- Show estimated total row count from existing table properties (with `~` prefix to indicate estimate)
- Hide redundant search counter when no search is active (previously showed "200 / 200")
- i18n support for EN / ZH / JA / ES

## Test plan

- [x] Connect to PostgreSQL and verify pagination works on a table with >200 rows
- [x] Connect to SQLite and verify pagination
- [x] Verify page size switching resets to page 1
- [x] Verify "Next" disables on last page
- [x] Verify search still works within current page
- [x] Verify table switching resets pagination
- [x] Verify total row estimate displays correctly

Closes #169