### PR TITLE
[codex] Allow proxy auth attempts to log

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -125,7 +125,7 @@ function createAuth() {
                                   action: 'challenge',
                               },
                               suspiciousIpBlocking: {
-                                  action: 'challenge',
+                                  action: 'log',
                               },
                               velocity: {
                                   enabled: true,


### PR DESCRIPTION
## Summary

- Change Better Auth Sentinel suspicious IP handling from challenge to log.
- Allow VPN/proxy/Tor auth attempts to continue while retaining Sentinel visibility.

## Why

GitHub/Google auth start requests were being blocked for users on anonymous proxy-like exits. Logging keeps observability without preventing sign-in.

## Validation

- `yarn workspace web run typecheck`
- `git rebase origin/main`