### PR TITLE
[codex] Enable Better Auth joins

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -217,9 +217,9 @@ function createAuth() {
 
         const auth = betterAuth({
             appName: 'Dory',
-            // experimental: {
-            //     joins: true,
-            // },
+            experimental: {
+                joins: true,
+            },
             database: drizzleAdapter(db, { provider, schema }),
             plugins: [
                 ...authPlugins,


### PR DESCRIPTION
## Summary

- Enable Better Auth experimental joins in the web auth configuration.
- Keep the existing Drizzle adapter schema wiring unchanged so Better Auth can use the relations already exported by the database schema package.

## Why

Better Auth can reduce related-data database round trips for endpoints such as `/get-session` and organization-heavy APIs when joins are enabled. The repo already exports auth relations through the shared Drizzle schema object and passes schema into the Postgres/PGlite Drizzle clients.

## Validation

- `git diff --check`
- `yarn workspace web run typecheck`
- `yarn workspace web exec node --import tsx --test scripts/tests/current-organization.test.ts scripts/tests/anonymous-link-strategy.test.ts scripts/tests/organization-provisioning.test.ts scripts/tests/session-cookie-header.test.ts`
