### PR TITLE
[codex] Fix Docker workspace manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@ COPY apps/admin/package.json ./apps/admin/
 COPY packages/actions/package.json ./packages/actions/
 COPY packages/analysis/package.json ./packages/analysis/
 COPY packages/auth-core/package.json ./packages/auth-core/
+COPY packages/cli/package.json ./packages/cli/
 COPY packages/database/package.json ./packages/database/
 COPY packages/drivers/package.json ./packages/drivers/
 COPY packages/ee/package.json ./packages/ee/
 COPY packages/files/package.json ./packages/files/
 COPY packages/i18n/package.json ./packages/i18n/
 COPY packages/mcp/package.json ./packages/mcp/
+COPY packages/server-core/package.json ./packages/server-core/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/ui/package.json ./packages/ui/
 COPY packages/web-utils/package.json ./packages/web-utils/


### PR DESCRIPTION
## Summary

- Add the missing `packages/server-core/package.json` copy to the Docker dependency layer.
- Add `packages/cli/package.json` so the Docker dependency layer includes all root workspace manifests.

## Why

The Docker build runs `yarn install --immutable` before copying the full source tree. Because the dependency layer did not include `packages/server-core/package.json`, Yarn did not recognize `@dory/server-core` as a local workspace and tried to resolve it from the public registry, causing a 404.

## Validation

- `git diff --check`
- Compared actual `apps/*` and `packages/*` workspace package manifests against Dockerfile COPY entries: no missing manifests.
- Recreated the Docker dependency install layer in a temporary directory and ran `CI=true YARN_NODE_LINKER=node-modules YARN_ENABLE_SCRIPTS=true yarn install --immutable`; resolution completed without the `@dory/server-core` registry 404.