### PR TITLE
[codex] Include Snowflake conditional export packages

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -52,6 +52,9 @@ const nextConfig = {
             '../../packages/database/src/postgres/migrations/**/*',
             '../../packages/database/src/pglite/migrations/**/*',
             '../../packages/i18n/src/locales/*.json',
+            '../../node_modules/async-function/**/*',
+            '../../node_modules/async-generator-function/**/*',
+            '../../node_modules/generator-function/**/*',
         ],
     },
     logging: {


### PR DESCRIPTION
## Summary

- Include Snowflake-related conditional-export helper packages in Next standalone output file tracing.
- Ensures `async-function/require.mjs`, `async-generator-function/require.mjs`, and `generator-function/require.mjs` are present in packaged Electron standalone resources.

## Root Cause

`snowflake-sdk` is server-externalized and loaded at runtime by Node. A transitive dependency can resolve conditional exports through the `module-sync` condition to `require.mjs`, but Next standalone tracing did not copy those files into the packaged `apps/web/node_modules` tree. The Electron app then failed at startup with `Cannot find module .../async-function/require.mjs`.

## Validation

- `yarn workspace web run build`
- `bash scripts/build-app-standalone.sh`
- Confirmed `release/standalone/apps/web/node_modules/async-function/require.mjs` exists after packaging.