### PR TITLE
Consolidate Agent Run SQL results and improve artifact navigation

### DIFF
--- a/apps/web/app/(app)/[organization]/[connectionId]/sql-console/hooks/useWorkHydration.ts
+++ b/apps/web/app/(app)/[organization]/[connectionId]/sql-console/hooks/useWorkHydration.ts
@@ -11,7 +11,7 @@ import { activeTabIdAtom } from '@/shared/stores/app.store';
 import type { UITabPayload } from '@dory/shared/types/tabs';
 import { sessionIdByTabAtom } from '../sql-console.store';
 import { getSessionStorageKey, normalizeSqlWorkspaceScope, type SqlWorkspaceScope } from '../workspace-scope';
-import { resolveWorkHydrationTarget } from '../work-hydration-target';
+import { consolidateAgentWorkspaceSessions, resolveWorkHydrationTarget } from '../work-hydration-target';
 import type { SqlWorkspaceInitialResultTarget } from '../initial-result-target';
 import { upsertActiveSetAtom } from '../components/result-table/stores/active-set.atoms';
 
@@ -97,7 +97,11 @@ export function useWorkHydration({
     const normalizedWorkspaceScope = useMemo(() => normalizeSqlWorkspaceScope(workspaceScope), [workspaceScope]);
     const workId = normalizedWorkspaceScope.workspaceMode === 'agent' ? normalizedWorkspaceScope.workId : null;
     const requestedTabId = initialResultTarget?.tabId ?? searchParams.get('tabId');
-    const requestedSessionId = initialResultTarget?.sessionId ?? searchParams.get('sessionId');
+    // Agent Run workspace URLs carry the latest execution session for backwards
+    // compatibility. It must not override the consolidated result session: a Run
+    // can contain multiple executions in the same SQL tab. Artifact deep links
+    // pass an explicit target and retain their exact-result behavior.
+    const requestedSessionId = initialResultTarget?.sessionId ?? (normalizedWorkspaceScope.workspaceMode === 'agent' ? null : searchParams.get('sessionId'));
     const activeTabId = useAtomValue(activeTabIdAtom);
     const setSessionIdMap = useSetAtom(sessionIdByTabAtom);
     const setActiveResult = useSetAtom(upsertActiveSetAtom);
@@ -167,9 +171,21 @@ export function useWorkHydration({
 
             if (cancelled) return;
 
-            snapshotRef.current = snapshot;
+            const hydratedSnapshot =
+                normalizedWorkspaceScope.workspaceMode === 'agent'
+                    ? {
+                          ...snapshot,
+                          sessions: consolidateAgentWorkspaceSessions(
+                              activeWorkId,
+                              snapshot.sessions ?? [],
+                              (snapshot.tabs ?? []).filter(tab => tab.tabType === 'sql').length === 1 ? (snapshot.tabs ?? []).find(tab => tab.tabType === 'sql')?.tabId : null,
+                          ),
+                      }
+                    : snapshot;
+
+            snapshotRef.current = hydratedSnapshot;
             setSnapshotRevision(revision => revision + 1);
-            for (const sessionSnapshot of snapshot.sessions ?? []) {
+            for (const sessionSnapshot of hydratedSnapshot.sessions ?? []) {
                 if (normalizedWorkspaceScope.workspaceMode === 'agent' && !initialResultTarget && sessionSnapshot.session.tabId) {
                     const latestSetIndex = sessionSnapshot.queryResultSets.reduce((latest, resultSet) => Math.max(latest, resultSet.setIndex), -1);
                     if (latestSetIndex >= 0) {

--- a/apps/web/app/(app)/[organization]/[connectionId]/sql-console/work-hydration-target.ts
+++ b/apps/web/app/(app)/[organization]/[connectionId]/sql-console/work-hydration-target.ts
@@ -10,6 +10,22 @@ export type WorkHydrationSessionLike = {
     };
 };
 
+type AgentWorkspaceResultSetLike = {
+    sessionId: string;
+    setIndex: number;
+};
+
+export type AgentWorkspaceSnapshotSessionLike = WorkHydrationSessionLike & {
+    session: WorkHydrationSessionLike['session'] & {
+        sessionId: string;
+        status?: string;
+        sqlText?: string;
+        resultSetCount?: number;
+    };
+    queryResultSets: AgentWorkspaceResultSetLike[];
+    results: unknown[][];
+};
+
 type SessionCandidate = {
     sessionId: string;
     tabId: string;
@@ -26,6 +42,61 @@ function timeValue(value: string | Date | null | undefined) {
 
 function sessionTime(session: WorkHydrationSessionLike['session']) {
     return Math.max(timeValue(session.finishedAt), timeValue(session.startedAt), timeValue(session.createdAt));
+}
+
+/**
+ * Agent tools commonly append several SQL executions to a single workspace tab.
+ * Unlike a console script, each tool call has its own query session. Present those
+ * result sets as one virtual session so the existing result toolbar can show every
+ * result in the tab instead of only the final execution.
+ */
+export function consolidateAgentWorkspaceSessions<T extends AgentWorkspaceSnapshotSessionLike>(workId: string, sessions: readonly T[], fallbackTabId?: string | null): T[] {
+    const groupedByTab = new Map<string, Array<{ session: T; originalIndex: number }>>();
+
+    sessions.forEach((session, originalIndex) => {
+        const tabId = session.session.tabId || fallbackTabId;
+        if (!tabId || session.queryResultSets.length === 0) return;
+
+        const group = groupedByTab.get(tabId) ?? [];
+        group.push({ session, originalIndex });
+        groupedByTab.set(tabId, group);
+    });
+
+    const consolidated = [...sessions];
+    for (const [tabId, group] of groupedByTab) {
+        if (group.length < 2) continue;
+
+        const ordered = group.toSorted((left, right) => {
+            const timeDelta = sessionTime(left.session.session) - sessionTime(right.session.session);
+            return timeDelta || left.originalIndex - right.originalIndex;
+        });
+        const latest = ordered.at(-1)!.session;
+        const flattened = ordered.flatMap(({ session }) =>
+            session.queryResultSets.map((resultSet, resultIndex) => ({
+                resultSet,
+                rows: Array.isArray(session.results[resultIndex]) ? session.results[resultIndex]! : [],
+            })),
+        );
+        const virtualSessionId = `agent-workspace:${workId}:${tabId}`;
+
+        consolidated.push({
+            ...latest,
+            session: {
+                ...latest.session,
+                sessionId: virtualSessionId,
+                tabId,
+                resultSetCount: flattened.length,
+            },
+            queryResultSets: flattened.map(({ resultSet }, setIndex) => ({
+                ...resultSet,
+                sessionId: virtualSessionId,
+                setIndex,
+            })),
+            results: flattened.map(({ rows }) => rows),
+        } as T);
+    }
+
+    return consolidated;
 }
 
 export function resolveWorkHydrationTarget({

--- a/apps/web/app/(app)/[organization]/agent-runs/[workId]/page.tsx
+++ b/apps/web/app/(app)/[organization]/agent-runs/[workId]/page.tsx
@@ -140,7 +140,7 @@ export default async function AgentRunDetailPage({
                                                         {item.evidence.length ? (
                                                             <div className="flex flex-wrap gap-2">
                                                                 {item.evidence.map(artifact => (
-                                                                    <Link key={artifact.id} href={`/${encodeURIComponent(organization)}/artifacts/${encodeURIComponent(artifact.id)}`} className="rounded-md border bg-muted px-2 py-1 text-xs hover:bg-accent">
+                                                                    <Link key={artifact.id} href={`/${encodeURIComponent(organization)}/artifacts/${encodeURIComponent(artifact.id)}?fromAgentRun=${encodeURIComponent(workId)}`} className="rounded-md border bg-muted px-2 py-1 text-xs hover:bg-accent">
                                                                         {artifact.title}{artifact.rowCount == null ? '' : ` · ${artifact.rowCount.toLocaleString()} rows`}
                                                                     </Link>
                                                                 ))}
@@ -188,7 +188,7 @@ export default async function AgentRunDetailPage({
                             <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                                 {artifacts.map(artifact => (
                                     <li key={artifact.id}>
-                                        <Link href={`/${encodeURIComponent(organization)}/artifacts/${encodeURIComponent(artifact.id)}`} className="flex items-center gap-3 rounded-md border p-3 hover:bg-accent">
+                                        <Link href={`/${encodeURIComponent(organization)}/artifacts/${encodeURIComponent(artifact.id)}?fromAgentRun=${encodeURIComponent(workId)}`} className="flex items-center gap-3 rounded-md border p-3 hover:bg-accent">
                                             <FileText className="h-4 w-4 text-muted-foreground" />
                                             <span className="min-w-0 truncate text-sm font-medium">{artifact.title}</span>
                                         </Link>

--- a/apps/web/app/(app)/[organization]/artifacts/[artifactId]/artifact-viewer.client.tsx
+++ b/apps/web/app/(app)/[organization]/artifacts/[artifactId]/artifact-viewer.client.tsx
@@ -66,8 +66,9 @@ function CompactMetadata({ artifact }: { artifact: ArtifactDetail }) {
     );
 }
 
-export function ArtifactViewerClient({ organization, artifactId }: { organization: string; artifactId: string }) {
+export function ArtifactViewerClient({ organization, artifactId, fromAgentRun }: { organization: string; artifactId: string; fromAgentRun: string | null }) {
     const t = useTranslations('Artifacts.Viewer');
+    const agentRunsT = useTranslations('AgentRuns');
     const router = useRouter();
     const organizationId = useOrganizationId();
     const queryClient = useQueryClient();
@@ -189,13 +190,17 @@ export function ArtifactViewerClient({ organization, artifactId }: { organizatio
     }
 
     const TypeIcon = artifact.type === 'result_set' ? Database : artifact.type === 'chart' ? BarChart3 : FileText;
+    const backHref = fromAgentRun
+        ? `/${encodeURIComponent(organization)}/agent-runs/${encodeURIComponent(fromAgentRun)}`
+        : `/${encodeURIComponent(organization)}/artifacts`;
+    const backLabel = fromAgentRun ? `${agentRunsT('List.Title')} - ${artifact.runTitle ?? fromAgentRun}` : t('Back');
     return (
         <div className="h-dvh overflow-hidden bg-n8">
             <main className="container mx-auto flex h-full min-h-0 flex-col gap-3 px-12 pb-6 pt-4 lg:px-12 xl:px-8 2xl:px-4">
                 <Button asChild variant="ghost" size="sm" className="w-fit -ml-2">
-                    <Link href={`/${encodeURIComponent(organization)}/artifacts`}>
+                    <Link href={backHref}>
                         <ArrowLeft className="h-4 w-4" />
-                        {t('Back')}
+                        {backLabel}
                     </Link>
                 </Button>
                 <header className="shrink-0 space-y-2 border-b pb-3">

--- a/apps/web/app/(app)/[organization]/artifacts/[artifactId]/page.tsx
+++ b/apps/web/app/(app)/[organization]/artifacts/[artifactId]/page.tsx
@@ -1,6 +1,13 @@
 import { ArtifactViewerClient } from './artifact-viewer.client';
 
-export default async function ArtifactViewerPage({ params }: { params: Promise<{ organization: string; artifactId: string }> }) {
+export default async function ArtifactViewerPage({
+    params,
+    searchParams,
+}: {
+    params: Promise<{ organization: string; artifactId: string }>;
+    searchParams: Promise<{ fromAgentRun?: string }>;
+}) {
     const { organization, artifactId } = await params;
-    return <ArtifactViewerClient organization={organization} artifactId={artifactId} />;
+    const { fromAgentRun } = await searchParams;
+    return <ArtifactViewerClient organization={organization} artifactId={artifactId} fromAgentRun={fromAgentRun ?? null} />;
 }

--- a/apps/web/app/(app)/[organization]/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/app/(app)/[organization]/components/app-sidebar/app-sidebar.tsx
@@ -151,12 +151,6 @@ export function AppSidebar({ initialUser = null, organizationId, enterpriseLicen
                   requiresConnection: false,
               },
               {
-                  title: t('Artifacts'),
-                  url: `/${organization}/artifacts`,
-                  icon: Archive,
-                  requiresConnection: false,
-              },
-              {
                   title: t('AgentRuns'),
                   url: `/${organization}/agent-runs`,
                   icon: Bot,
@@ -166,6 +160,16 @@ export function AppSidebar({ initialUser = null, organizationId, enterpriseLicen
                   title: t('SchemaCompare'),
                   url: `/${organization}/comparisons`,
                   icon: GitCompareArrows,
+                  requiresConnection: false,
+              },
+          ];
+    const moreItems = connectionId
+        ? []
+        : [
+              {
+                  title: t('Artifacts'),
+                  url: `/${organization}/artifacts`,
+                  icon: Archive,
                   requiresConnection: false,
               },
           ];
@@ -231,7 +235,7 @@ export function AppSidebar({ initialUser = null, organizationId, enterpriseLicen
             <SidebarHeader className="pb-2">{connectionId ? <ConnectionSwitcher /> : <ConnectionSwitcher displayMode="all-connections" />}</SidebarHeader>
 
             <SidebarContent>
-                <NavMain items={navMain} disabled={!connectionId} hasActiveConnection={!!connectionId} />
+                <NavMain items={navMain} moreItems={moreItems} moreTitle={t('More')} disabled={!connectionId} hasActiveConnection={!!connectionId} />
                 <div className="mt-auto space-y-2">
                     {showStarNotification ? (
                         <div className="px-2 group-data-[collapsible=icon]:hidden">

--- a/apps/web/app/(app)/[organization]/components/app-sidebar/nav-main.tsx
+++ b/apps/web/app/(app)/[organization]/components/app-sidebar/nav-main.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import type React from 'react';
+import { useEffect, useState, type ComponentType } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
 import { cn } from '@dory/web-utils';
-import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/registry/new-york-v4/ui/sidebar';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/registry/new-york-v4/ui/collapsible';
+import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarMenuSub, SidebarMenuSubButton, SidebarMenuSubItem } from '@/registry/new-york-v4/ui/sidebar';
 
 export type NavItem = {
     title: string;
     url: string;
     matchPrefix?: string;
-    icon?: React.ComponentType<{ className?: string }>;
+    icon?: ComponentType<{ className?: string }>;
     requiresConnection?: boolean;
 };
 
@@ -18,18 +20,34 @@ function getIsDisabled(item: NavItem, disabled: boolean, hasActiveConnection: bo
     return item.requiresConnection ? disabled || !hasActiveConnection : false;
 }
 
+function getIsActive(item: NavItem, pathname: string, disabled: boolean, hasActiveConnection: boolean) {
+    if (getIsDisabled(item, disabled, hasActiveConnection)) return false;
+    const matchBase = item.matchPrefix ?? item.url;
+    return pathname === item.url || pathname.startsWith(`${item.url}/`) || pathname === matchBase || pathname.startsWith(`${matchBase}/`);
+}
+
 export function NavMain({
     items,
     disabled = false,
     hasActiveConnection = false,
+    moreItems = [],
+    moreTitle,
     className,
 }: {
     items: NavItem[];
     disabled?: boolean;
     hasActiveConnection?: boolean;
+    moreItems?: NavItem[];
+    moreTitle?: string;
     className?: string;
 }) {
     const pathname = usePathname();
+    const hasActiveMoreItem = moreItems.some(item => getIsActive(item, pathname, disabled, hasActiveConnection));
+    const [moreOpen, setMoreOpen] = useState(hasActiveMoreItem);
+
+    useEffect(() => {
+        if (hasActiveMoreItem) setMoreOpen(true);
+    }, [hasActiveMoreItem]);
 
     return (
         <SidebarGroup className={cn(className)}>
@@ -38,10 +56,7 @@ export function NavMain({
                     {items.map(item => {
                         const IconComp = item.icon;
                         const itemDisabled = getIsDisabled(item, disabled, hasActiveConnection);
-
-                        const matchBase = item.matchPrefix ?? item.url;
-                        const isActive =
-                            !itemDisabled && (pathname === item.url || pathname.startsWith(`${item.url}/`) || pathname === matchBase || pathname.startsWith(`${matchBase}/`));
+                        const isActive = getIsActive(item, pathname, disabled, hasActiveConnection);
 
                         const content = itemDisabled ? (
                             <span
@@ -80,6 +95,53 @@ export function NavMain({
                             </SidebarMenuItem>
                         );
                     })}
+                    {moreItems.length && moreTitle ? (
+                        <Collapsible asChild open={moreOpen} onOpenChange={setMoreOpen} className="group/collapsible">
+                            <SidebarMenuItem>
+                                <CollapsibleTrigger asChild>
+                                    <SidebarMenuButton
+                                        type="button"
+                                        tooltip={moreTitle}
+                                    >
+                                        <MoreHorizontal className="h-4 w-4 shrink-0" />
+                                        <span>{moreTitle}</span>
+                                        <ChevronRight className="ml-auto h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                                    </SidebarMenuButton>
+                                </CollapsibleTrigger>
+                                <CollapsibleContent>
+                                    <SidebarMenuSub>
+                                        {moreItems.map(item => {
+                                            const IconComp = item.icon;
+                                            const itemDisabled = getIsDisabled(item, disabled, hasActiveConnection);
+                                            const isActive = getIsActive(item, pathname, disabled, hasActiveConnection);
+
+                                            return (
+                                                <SidebarMenuSubItem key={item.title}>
+                                                    {itemDisabled ? (
+                                                        <span aria-disabled="true" className="flex cursor-not-allowed items-center gap-2 px-2 text-sm text-muted-foreground opacity-60">
+                                                            {IconComp ? <IconComp className="h-4 w-4 shrink-0" /> : null}
+                                                            <span>{item.title}</span>
+                                                        </span>
+                                                    ) : (
+                                                        <SidebarMenuSubButton
+                                                            asChild
+                                                            isActive={isActive}
+                                                            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:hover:bg-primary/90 data-[active=true]:hover:text-primary-foreground data-[active=true]:active:bg-primary/90 data-[active=true]:active:text-primary-foreground data-[active=true]:[&>svg]:!text-primary-foreground"
+                                                        >
+                                                            <Link href={item.url} prefetch={false}>
+                                                                {IconComp ? <IconComp className="h-4 w-4 shrink-0" /> : null}
+                                                                <span>{item.title}</span>
+                                                            </Link>
+                                                        </SidebarMenuSubButton>
+                                                    )}
+                                                </SidebarMenuSubItem>
+                                            );
+                                        })}
+                                    </SidebarMenuSub>
+                                </CollapsibleContent>
+                            </SidebarMenuItem>
+                        </Collapsible>
+                    ) : null}
                 </SidebarMenu>
             </SidebarGroupContent>
         </SidebarGroup>

--- a/apps/web/scripts/tests/artifact-workspace-target.test.ts
+++ b/apps/web/scripts/tests/artifact-workspace-target.test.ts
@@ -59,8 +59,12 @@ test('does not expose Open for files, comparisons, or incomplete SQL context', (
 });
 
 test('derives a semantic Artifact title from SQL instead of exposing the statement', () => {
-    assert.equal(formatSqlResultTitle('SELECT * FROM production_logs'), 'Production Logs query');
-    assert.equal(formatSqlResultTitle('SELECT count(*) FROM orders'), 'Orders query');
+    assert.equal(formatSqlResultTitle('SELECT * FROM production_logs'), 'Production Logs — *');
+    assert.equal(formatSqlResultTitle('SELECT count(*) AS order_count FROM orders'), 'Orders — order count');
+    assert.notEqual(
+        formatSqlResultTitle('SELECT country, COUNT(*) AS user_count FROM users GROUP BY country'),
+        formatSqlResultTitle('SELECT substr(created_at, 1, 7) AS signup_month, COUNT(*) AS user_count FROM users GROUP BY signup_month'),
+    );
 });
 
 test('builds an Artifact-only workspace URL without source session parameters', () => {

--- a/apps/web/scripts/tests/work-hydration-target.test.ts
+++ b/apps/web/scripts/tests/work-hydration-target.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { resolveWorkHydrationTarget } from '@/app/(app)/[organization]/[connectionId]/sql-console/work-hydration-target';
+import { consolidateAgentWorkspaceSessions, resolveWorkHydrationTarget } from '@/app/(app)/[organization]/[connectionId]/sql-console/work-hydration-target';
 import type { UITabPayload } from '@dory/shared/types/tabs';
 
 const tabs = [
@@ -147,4 +147,88 @@ test('work hydration maps session ids even when no tabs are loaded yet', () => {
     });
     assert.equal(target.targetTabId, 'tab-2');
     assert.equal(target.targetSessionId, 'session-2');
+});
+
+test('Agent Workspace combines separate executions in one tab into result tabs', () => {
+    const sessions = consolidateAgentWorkspaceSessions('work-1', [
+        {
+            session: {
+                sessionId: 'session-1',
+                tabId: 'tab-1',
+                status: 'success',
+                startedAt: '2026-06-01T00:00:00.000Z',
+            },
+            queryResultSets: [{ sessionId: 'session-1', setIndex: 0, resultSetId: 'result-1' }],
+            results: [[{ value: 1 }]],
+        },
+        {
+            session: {
+                sessionId: 'session-2',
+                tabId: 'tab-1',
+                status: 'success',
+                startedAt: '2026-06-01T00:01:00.000Z',
+            },
+            queryResultSets: [
+                { sessionId: 'session-2', setIndex: 0, resultSetId: 'result-2' },
+                { sessionId: 'session-2', setIndex: 1, resultSetId: 'result-3' },
+            ],
+            results: [[{ value: 2 }], [{ value: 3 }]],
+        },
+    ]);
+
+    const virtualSession = sessions.at(-1)!;
+    assert.equal(virtualSession.session.sessionId, 'agent-workspace:work-1:tab-1');
+    assert.equal((virtualSession.session as { resultSetCount?: number }).resultSetCount, 3);
+    assert.deepEqual(
+        virtualSession.queryResultSets.map(resultSet => [resultSet.sessionId, resultSet.setIndex, resultSet.resultSetId]),
+        [
+            ['agent-workspace:work-1:tab-1', 0, 'result-1'],
+            ['agent-workspace:work-1:tab-1', 1, 'result-2'],
+            ['agent-workspace:work-1:tab-1', 2, 'result-3'],
+        ],
+    );
+    assert.deepEqual(virtualSession.results, [[{ value: 1 }], [{ value: 2 }], [{ value: 3 }]]);
+
+    const target = resolveWorkHydrationTarget({
+        tabs: [tabs[0]!],
+        sessions,
+        requestedTabId: 'tab-1',
+    });
+    assert.equal(target.targetSessionId, 'agent-workspace:work-1:tab-1');
+});
+
+test('Agent Workspace assigns unbound historical sessions to its only SQL tab', () => {
+    const sessions = consolidateAgentWorkspaceSessions(
+        'work-1',
+        [
+            {
+                session: {
+                    sessionId: 'session-1',
+                    tabId: '',
+                    status: 'success',
+                    startedAt: '2026-06-01T00:00:00.000Z',
+                },
+                queryResultSets: [{ sessionId: 'session-1', setIndex: 0, resultSetId: 'result-1' }],
+                results: [[{ value: 1 }]],
+            },
+            {
+                session: {
+                    sessionId: 'session-2',
+                    tabId: 'tab-1',
+                    status: 'success',
+                    startedAt: '2026-06-01T00:01:00.000Z',
+                },
+                queryResultSets: [{ sessionId: 'session-2', setIndex: 0, resultSetId: 'result-2' }],
+                results: [[{ value: 2 }]],
+            },
+        ],
+        'tab-1',
+    );
+
+    const virtualSession = sessions.at(-1)!;
+    assert.equal(virtualSession.session.tabId, 'tab-1');
+    assert.deepEqual(
+        virtualSession.queryResultSets.map(resultSet => resultSet.resultSetId),
+        ['result-1', 'result-2'],
+    );
 });

--- a/packages/database/src/postgres/impl/artifacts/index.ts
+++ b/packages/database/src/postgres/impl/artifacts/index.ts
@@ -140,12 +140,18 @@ export function formatSqlResultTitle(sql: string | null) {
               .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
               .join(' ')
         : 'Query';
+    const projection = normalized.match(/\bselect\s+(.+?)\s+\bfrom\b/i)?.[1];
+    const aliases = projection?.match(/\bas\s+["`]?([a-zA-Z0-9_.-]+)/gi)?.map(alias => alias.replace(/^\bas\s+/i, '').replace(/["`]/g, '')) ?? [];
+    const detail = aliases.length ? aliases.join(', ') : projection;
+    if (/\bselect\b/i.test(normalized) && detail) {
+        const readableDetail = detail.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+        return `${subject} — ${readableDetail.slice(0, 72)}${readableDetail.length > 72 ? '…' : ''}`;
+    }
     if (/^\s*select\b/i.test(normalized)) return `${subject} query`;
     return `${subject} result`;
 }
 
-function displayTitle(input: { artifact: typeof artifacts.$inferSelect; runTitle: string | null; resultSetSql: string | null }) {
-    if (input.artifact.type === 'result_set' && input.artifact.agentRunId && input.runTitle) return input.runTitle;
+function displayTitle(input: { artifact: typeof artifacts.$inferSelect; resultSetSql: string | null }) {
     return isSqlTitle(input.artifact.title) ? formatSqlResultTitle(input.resultSetSql) : input.artifact.title;
 }
 
@@ -458,7 +464,7 @@ export class PostgresArtifactsRepository {
                 : null;
         return {
             ...row.artifact,
-            title: displayTitle({ artifact: row.artifact, runTitle: row.runTitle, resultSetSql: row.resultSetSql ?? null }),
+            title: displayTitle({ artifact: row.artifact, resultSetSql: row.resultSetSql ?? null }),
             connectionName: row.connectionName,
             runTitle: row.runTitle,
             comparisonName: row.comparisonName,

--- a/packages/database/src/postgres/impl/works/index.ts
+++ b/packages/database/src/postgres/impl/works/index.ts
@@ -561,25 +561,9 @@ export class PostgresWorksRepository {
             },
         };
 
-        // Agents sometimes omit evidence IDs even when the Run produced snapshots.
-        // Use those snapshots as a new-Finding fallback; explicit IDs still take
-        // precedence and a Run with no Artifacts remains uncited.
-        const inferredEvidenceArtifactIds = await this.db
-            .select({ id: artifacts.id })
-            .from(artifacts)
-            .where(
-                and(
-                    eq(artifacts.organizationId, input.organizationId),
-                    or(eq(artifacts.workId, input.workId), eq(artifacts.agentRunId, input.workId)),
-                ),
-            )
-            .orderBy(desc(artifacts.createdAt))
-            .limit(20);
-        const findingsToCreate = normalizedFindings.map(finding =>
-            !finding.evidenceArtifactIds.length && inferredEvidenceArtifactIds.length
-                ? { ...finding, evidenceArtifactIds: inferredEvidenceArtifactIds.map(artifact => artifact.id) }
-                : finding,
-        );
+        // Evidence must be explicitly cited by the agent. Attaching every Artifact
+        // from a Run to a Finding when IDs are omitted creates false evidence links.
+        const findingsToCreate = normalizedFindings;
 
         const [row] = await this.db.transaction(async tx => {
             const evidenceIds = [...new Set(findingsToCreate.flatMap(finding => finding.evidenceArtifactIds))];

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3747,6 +3747,7 @@
     "AppSidebar": {
         "DataSources": "Data Sources",
         "Artifacts": "Artifacts",
+        "More": "More",
         "NoDataSourceSelected": "No data source selected",
         "WorkspaceTitle": "Workspace",
         "WorkspaceDataSourcesCount": "{count} data source",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -3740,6 +3740,8 @@
     },
     "AppSidebar": {
         "DataSources": "Fuentes de datos",
+        "Artifacts": "Artifacts",
+        "More": "Más",
         "NoDataSourceSelected": "Sin fuente de datos seleccionada",
         "WorkspaceTitle": "Espacio de trabajo",
         "WorkspaceDataSourcesCount": "{count} fuente de datos",

--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -3747,6 +3747,7 @@
     "AppSidebar": {
         "DataSources": "データソース",
         "Artifacts": "Artifacts",
+        "More": "その他",
         "NoDataSourceSelected": "データソース未選択",
         "WorkspaceTitle": "ワークスペース",
         "WorkspaceDataSourcesCount": "{count} 件のデータソース",

--- a/packages/i18n/src/locales/zh.json
+++ b/packages/i18n/src/locales/zh.json
@@ -3737,6 +3737,7 @@
     "AppSidebar": {
         "DataSources": "数据源",
         "Artifacts": "Artifacts",
+        "More": "更多",
         "NoDataSourceSelected": "未选择数据源",
         "WorkspaceTitle": "工作区",
         "WorkspaceDataSourcesCount": "{count} 个数据源",


### PR DESCRIPTION
## Summary

- Combine multiple Agent Run SQL executions into a virtual session per tab so all result sets remain accessible.
- Preserve explicit artifact result targets while preventing legacy session parameters from overriding consolidated results.
- Add Agent Run context to artifact links with contextual back navigation.
- Move Artifacts under the sidebar’s More menu when no connection is selected.
- Improve SQL-derived artifact titles with projection or alias details.
- Add coverage for session consolidation, historical sessions, and artifact title generation.

## Testing

- Not run (not requested)